### PR TITLE
fix(eventbus): fix connection drops, context leaks, and structured lo…

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -58,12 +58,21 @@ func NewGossipMongerApp(logger *slog.Logger, cfg *config.Config) (*GossipMonger,
 		cfg.RabbitMQConfig.RabbitMQPort,
 	)
 
-	bus, err := eventbus.NewRabbitMQEventBus(rabbitMQConnString, "verisafe.exchange", eventbus.FanoutExchangeType)
+	bus, err := eventbus.NewRabbitMQEventBus(
+		rabbitMQConnString,
+		"verisafe.exchange",
+		eventbus.FanoutExchangeType, logger,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to rabbit mq  event bus %w", err)
 	}
 
-	nbus, err := eventbus.NewRabbitMQEventBus(rabbitMQConnString, "gossip-monger.exchange", eventbus.DirectExchangeType)
+	nbus, err := eventbus.NewRabbitMQEventBus(
+		rabbitMQConnString,
+		"gossip-monger.exchange",
+		eventbus.DirectExchangeType,
+		logger,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to rabbit mq  event bus %w", err)
 	}
@@ -101,9 +110,9 @@ func (gm *GossipMonger) Start(ctx context.Context) error {
 	database.RunGooseMigrations(gm.logger, gm.pool)
 
 	// Setup verisafe event subscriptions
-	gm.userEventBus.SetupEventSubscriptions(ctx)
-	gm.notificationEventBus.SetupEventSubscriptions(ctx)
-	gm.emailEventBus.SetupEventSubscriptions(ctx)
+	gm.userEventBus.SetupEventSubscriptions()
+	gm.notificationEventBus.SetupEventSubscriptions()
+	gm.emailEventBus.SetupEventSubscriptions()
 
 	router := LoadRoutes(gm)
 
@@ -147,6 +156,9 @@ func (gm *GossipMonger) Start(ctx context.Context) error {
 	defer cancel()
 
 	srv.Shutdown(sCtx)
+	gm.userEventBus.Close()
+	gm.notificationEventBus.Close()
+	gm.emailEventBus.Close()
 
 	return nil
 

--- a/internal/eventbus/client.go
+++ b/internal/eventbus/client.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"sync"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 )
@@ -13,132 +16,289 @@ type ExchangeType string
 const (
 	DirectExchangeType ExchangeType = "direct"
 	FanoutExchangeType ExchangeType = "fanout"
-	TopicExhangeType   ExchangeType = "topic"
+	TopicExchangeType  ExchangeType = "topic"
+
+	reconnectDelay = 5 * time.Second
 )
 
 // EventBus is an interface that defines the contract for any event bus implementation.
-// The Publish method now accepts a routing key.
 type EventBus interface {
 	Publish(ctx context.Context, routingKey string, event any) error
 	Subscribe(routingKey string, handler func(event []byte)) error
 	Close()
 }
 
+// subscription holds the info needed to re-register a consumer after reconnect.
+type subscription struct {
+	routingKey string
+	handler    func([]byte)
+}
+
 // RabbitMQEventBus is a concrete implementation of EventBus that uses RabbitMQ.
+// It maintains a dedicated publish channel and creates a new channel per subscriber.
+// It automatically reconnects on connection loss.
 type RabbitMQEventBus struct {
-	conn     *amqp.Connection
-	channel  *amqp.Channel
-	exchange string
+	amqpURI      string
+	exchange     string
+	exchangeType ExchangeType
+	logger       *slog.Logger
+
+	mu        sync.RWMutex
+	conn      *amqp.Connection
+	publishCh *amqp.Channel // dedicated channel for publishing
+
+	subscriptions []subscription // kept so we can re-subscribe on reconnect
+
+	done chan struct{} // closed when Close() is called
 }
 
 // NewRabbitMQEventBus creates and returns a new RabbitMQEventBus instance.
-// It connects to the RabbitMQ server and declares a durable exchange.
-func NewRabbitMQEventBus(amqpURI, exchange string, exchangeType ExchangeType) (*RabbitMQEventBus, error) {
-	conn, err := amqp.Dial(amqpURI)
-	if err != nil {
+// It connects to RabbitMQ and declares a durable exchange, then starts a
+// background goroutine that reconnects automatically on connection loss.
+func NewRabbitMQEventBus(amqpURI, exchange string, exchangeType ExchangeType, logger *slog.Logger) (*RabbitMQEventBus, error) {
+	eb := &RabbitMQEventBus{
+		amqpURI:      amqpURI,
+		exchange:     exchange,
+		exchangeType: exchangeType,
+		logger:       logger,
+		done:         make(chan struct{}),
+	}
+
+	if err := eb.connect(); err != nil {
 		return nil, err
 	}
 
-	ch, err := conn.Channel()
-	if err != nil {
-		return nil, err
-	}
+	go eb.reconnectLoop()
 
-	// Declare a durable direct exchange
-	err = ch.ExchangeDeclare(
-		exchange,                   // name
-		string(exchangeType), // type
-		true,                       // durable
-		false,                      // auto-deleted
-		false,                      // internal
-		false,                      // no-wait
-		nil,                        // arguments
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return &RabbitMQEventBus{
-		conn:     conn,
-		channel:  ch,
-		exchange: exchange,
-	}, nil
+	return eb, nil
 }
 
-// Publish serializes the event and sends it to the RabbitMQ exchange.
-func (eb *RabbitMQEventBus) Publish(ctx context.Context, routingKey string, event interface{}) error {
+// connect establishes the AMQP connection, declares the exchange, and opens
+// a dedicated publish channel. It is called both on initial startup and after
+// a connection drop is detected.
+func (eb *RabbitMQEventBus) connect() error {
+	conn, err := amqp.DialConfig(eb.amqpURI, amqp.Config{
+		Heartbeat: 10 * time.Second,
+		Locale:    "en_US",
+	})
+	if err != nil {
+		return fmt.Errorf("amqp dial: %w", err)
+	}
+
+	publishCh, err := conn.Channel()
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("open publish channel: %w", err)
+	}
+
+	if err = publishCh.ExchangeDeclare(
+		eb.exchange,
+		string(eb.exchangeType),
+		true,  // durable
+		false, // auto-deleted
+		false, // internal
+		false, // no-wait
+		nil,
+	); err != nil {
+		conn.Close()
+		return fmt.Errorf("declare exchange: %w", err)
+	}
+
+	eb.mu.Lock()
+	eb.conn = conn
+	eb.publishCh = publishCh
+	eb.mu.Unlock()
+
+	return nil
+}
+
+// reconnectLoop watches for connection-level close notifications and
+// re-establishes the connection (and all subscriptions) automatically.
+func (eb *RabbitMQEventBus) reconnectLoop() {
+	for {
+		eb.mu.RLock()
+		conn := eb.conn
+		eb.mu.RUnlock()
+
+		connClose := conn.NotifyClose(make(chan *amqp.Error, 1))
+
+		select {
+		case <-eb.done:
+			return
+		case amqpErr, ok := <-connClose:
+			if !ok {
+				// channel closed without error — shutting down cleanly
+				return
+			}
+			eb.logger.Warn("eventbus connection lost, reconnecting",
+				slog.Any("error", amqpErr),
+				slog.Duration("delay", reconnectDelay),
+			)
+		}
+
+		// Back-off then reconnect.
+		select {
+		case <-eb.done:
+			return
+		case <-time.After(reconnectDelay):
+		}
+
+		for {
+			if err := eb.connect(); err != nil {
+				eb.logger.Error("eventbus reconnect failed, retrying",
+					slog.Any("error", err),
+					slog.Duration("delay", reconnectDelay),
+				)
+				select {
+				case <-eb.done:
+					return
+				case <-time.After(reconnectDelay):
+				}
+				continue
+			}
+			eb.logger.Info("eventbus reconnected successfully")
+			break
+		}
+
+		// Re-register all existing subscriptions on the new connection.
+		eb.mu.RLock()
+		subs := make([]subscription, len(eb.subscriptions))
+		copy(subs, eb.subscriptions)
+		eb.mu.RUnlock()
+
+		for _, s := range subs {
+			if err := eb.startConsumer(s.routingKey, s.handler); err != nil {
+				eb.logger.Error("eventbus failed to re-subscribe after reconnect",
+					slog.String("routing_key", s.routingKey),
+					slog.Any("error", err),
+				)
+			}
+		}
+	}
+}
+
+// Publish serialises the event and sends it to the RabbitMQ exchange using
+// the dedicated publish channel.
+func (eb *RabbitMQEventBus) Publish(ctx context.Context, routingKey string, event any) error {
 	body, err := json.Marshal(event)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal event: %w", err)
 	}
 
-	publishing := amqp.Publishing{
-		ContentType:  "application/json",
-		Body:         body,
-		DeliveryMode: amqp.Persistent, // Make message persistent
+	eb.mu.RLock()
+	ch := eb.publishCh
+	eb.mu.RUnlock()
+
+	if ch == nil {
+		return fmt.Errorf("eventbus: not connected")
 	}
 
-	return eb.channel.PublishWithContext(
+	return ch.PublishWithContext(
 		ctx,
 		eb.exchange,
 		routingKey,
 		false, // mandatory
 		false, // immediate
-		publishing,
+		amqp.Publishing{
+			ContentType:  "application/json",
+			Body:         body,
+			DeliveryMode: amqp.Persistent,
+		},
 	)
 }
 
-// Subscribe declares a queue, binds it to the exchange, and consumes messages.
+// Subscribe declares a durable queue, binds it to the exchange with the given
+// routing key, and begins consuming messages in a background goroutine.
+// Each subscriber gets its own AMQP channel (required by RabbitMQ).
 func (eb *RabbitMQEventBus) Subscribe(routingKey string, handler func(event []byte)) error {
-	queueName := fmt.Sprintf("io.opencrafts.gossip-monger.%s", routingKey)
-	// Declare a durable, non-exclusive queue
-	q, err := eb.channel.QueueDeclare(
-		queueName, // Name, RabbitMQ will generate a unique name
-		true,      // Durable
-		true,      // Delete when unused
-		false,     // Not exclusive to this consumer
-		false,     // No-wait
-		nil,       // Arguments
-	)
-	if err != nil {
-		return err
+	eb.mu.Lock()
+	eb.subscriptions = append(eb.subscriptions, subscription{routingKey, handler})
+	eb.mu.Unlock()
+
+	return eb.startConsumer(routingKey, handler)
+}
+
+// startConsumer opens a fresh channel and wires up a consumer for the given
+// routing key. It also watches for channel-level close events and logs them
+// (reconnection is handled at the connection level by reconnectLoop).
+func (eb *RabbitMQEventBus) startConsumer(routingKey string, handler func([]byte)) error {
+	eb.mu.RLock()
+	conn := eb.conn
+	eb.mu.RUnlock()
+
+	if conn == nil {
+		return fmt.Errorf("eventbus: not connected")
 	}
 
-	// Bind the queue to the exchange with a specific routing key
-	err = eb.channel.QueueBind(
-		q.Name,      // queue name
-		routingKey,  // routing key
-		eb.exchange, // exchange
-		false,
+	// Each consumer gets its own channel — RabbitMQ best practice.
+	ch, err := conn.Channel()
+	if err != nil {
+		return fmt.Errorf("open consumer channel: %w", err)
+	}
+
+	queueName := fmt.Sprintf("io.opencrafts.gossip-monger.%s", routingKey)
+
+	q, err := ch.QueueDeclare(
+		queueName,
+		true,  // durable
+		false, // do NOT auto-delete — keeps the queue alive between consumer restarts
+		false, // not exclusive
+		false, // no-wait
 		nil,
 	)
 	if err != nil {
-		return err
+		ch.Close()
+		return fmt.Errorf("declare queue %q: %w", queueName, err)
 	}
 
-	msgs, err := eb.channel.Consume(
-		q.Name, // queue
-		"",     // consumer
-		false,  // auto-ack (set to false for manual acknowledgment)
-		false,  // exclusive
-		false,  // no-local
-		false,  // no-wait
-		nil,    // args
+	if err = ch.QueueBind(q.Name, routingKey, eb.exchange, false, nil); err != nil {
+		ch.Close()
+		return fmt.Errorf("bind queue %q: %w", q.Name, err)
+	}
+
+	msgs, err := ch.Consume(
+		q.Name,
+		"",    // consumer tag — let RabbitMQ generate one
+		false, // auto-ack disabled — we ack manually after processing
+		false, // not exclusive
+		false, // no-local
+		false, // no-wait
+		nil,
 	)
 	if err != nil {
-		return err
+		ch.Close()
+		return fmt.Errorf("consume queue %q: %w", q.Name, err)
 	}
 
-	// Start a goroutine to process messages
 	go func() {
-		for d := range msgs {
-			// Process the message
-			handler(d.Body)
+		chClose := ch.NotifyClose(make(chan *amqp.Error, 1))
+		for {
+			select {
+			case d, ok := <-msgs:
+				if !ok {
+					// msgs channel closed — connection was lost; reconnectLoop will handle it.
+					return
+				}
+				handler(d.Body)
+				if err := d.Ack(false); err != nil {
+					eb.logger.Error("eventbus ack failed",
+						slog.String("routing_key", routingKey),
+						slog.Any("error", err),
+					)
+				}
 
-			// Manually acknowledge the message
-			if err := d.Ack(false); err != nil {
-				// Log error but continue processing
-				// In a production environment, you might want to implement retry logic
+			case amqpErr, ok := <-chClose:
+				if ok {
+					eb.logger.Warn("eventbus consumer channel closed",
+						slog.String("routing_key", routingKey),
+						slog.Any("error", amqpErr),
+					)
+				}
+				return
+
+			case <-eb.done:
+				ch.Close()
+				return
 			}
 		}
 	}()
@@ -146,8 +306,19 @@ func (eb *RabbitMQEventBus) Subscribe(routingKey string, handler func(event []by
 	return nil
 }
 
-// Close closes the RabbitMQ channel and connection.
+// Close gracefully shuts down the event bus, stopping all consumers and
+// closing the AMQP connection.
 func (eb *RabbitMQEventBus) Close() {
-	eb.channel.Close()
-	eb.conn.Close()
+	close(eb.done)
+
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+
+	if eb.publishCh != nil {
+		eb.publishCh.Close()
+	}
+	if eb.conn != nil {
+		eb.conn.Close()
+	}
 }
+

--- a/internal/eventbus/email_event_bus.go
+++ b/internal/eventbus/email_event_bus.go
@@ -10,68 +10,82 @@ import (
 	"github.com/resend/resend-go/v2"
 )
 
+const (
+	emailRoutingKey        = "gossip-monger.email"
+	expectedEmailEventType = "email.send"
+)
+
+// EmailEventBus provides a type-safe API for email events.
 type EmailEventBus struct {
 	bus          EventBus
 	logger       *slog.Logger
-	pool         *pgxpool.Pool
-	client       *resend.Client
 	emailHandler *EmailEventHandler
+
+	// ctx is a long-lived context owned by EmailEventBus, used by subscriber
+	// handlers. It is independent of any caller context so that handlers
+	// remain active for the lifetime of the bus.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
-// Returns a new EmailEventBus for performing email related tasks
+// NewEmailEventBus creates a new EmailEventBus for performing email related tasks.
 func NewEmailEventBus(
-	bus EventBus, pool *pgxpool.Pool,
+	bus EventBus,
+	pool *pgxpool.Pool,
 	client *resend.Client,
 	logger *slog.Logger,
 ) *EmailEventBus {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &EmailEventBus{
 		bus:          bus,
-		pool:         pool,
-		client:       client,
 		logger:       logger,
 		emailHandler: NewEmailEventHandler(pool, client, logger),
+		ctx:          ctx,
+		cancel:       cancel,
 	}
 }
 
-func (b *EmailEventBus) SetupEventSubscriptions(ctx context.Context) error {
-	if err := b.SubscribeEmailSendRequested(ctx, b.emailHandler.HandleEmailSendRequested); err != nil {
-		return fmt.Errorf("Failed to subscribe to email sending event %w", err)
+// SetupEventSubscriptions registers all event subscriptions for the application.
+func (b *EmailEventBus) SetupEventSubscriptions() error {
+	if err := b.subscribeEmailSendRequested(); err != nil {
+		return fmt.Errorf("failed to subscribe to email send events: %w", err)
 	}
-
-	b.logger.Info("Gossip email subscriptions set up successfully")
-
+	b.logger.Info("email event subscriptions set up successfully")
 	return nil
 }
 
-func (b *EmailEventBus) SubscribeEmailSendRequested(
-	ctx context.Context,
-	handler func(context context.Context, event EmailEvent),
-) error {
-	// Use the same routing key as the publisher
-	routingKey := "gossip-monger.email"
+// Close cancels the internal context, signalling all active handlers to stop.
+func (b *EmailEventBus) Close() {
+	b.cancel()
+}
 
-	// Subscribe to the generic event bus, and wrap the handler to unmarshal the data
-	return b.bus.Subscribe(routingKey, func(data []byte) {
+// subscribeEmailSendRequested listens for services requesting emails to be sent.
+func (b *EmailEventBus) subscribeEmailSendRequested() error {
+	return b.bus.Subscribe(emailRoutingKey, func(data []byte) {
 		var event EmailEvent
 		if err := json.Unmarshal(data, &event); err != nil {
-			// Log the error but don't stop the consumer
-			// A dead-letter queue or logging service could be used here
-			b.logger.Error("Error unmarshalling data", slog.Any("error", err))
+			b.logger.Error("failed to unmarshal email event",
+				slog.String("routing_key", emailRoutingKey),
+				slog.Any("error", err),
+			)
 			return
 		}
 
-		if event.Metadata.EventType != "email.send" {
-			b.logger.Error(fmt.Sprintf(
-				"Wrong metadata event type expected email.send instead got %s",
-				event.Metadata.EventType,
-			),
-				slog.String("requested", "email.send"),
-				/// Log that the operation was aborted by the service to maintain consistency
+		if event.Metadata.EventType != expectedEmailEventType {
+			b.logger.Error("email event rejected: unexpected event type",
+				slog.String("routing_key", emailRoutingKey),
+				slog.String("expected_event_type", expectedEmailEventType),
+				slog.String("actual_event_type", event.Metadata.EventType),
 				slog.Bool("abort", true),
 			)
 			return
 		}
-		handler(ctx, event)
-	})
 
+		b.emailHandler.HandleEmailSendRequested(b.ctx, event)
+
+		b.logger.Info("email event handled successfully",
+			slog.String("event_type", event.Metadata.EventType),
+		)
+	})
 }
+

--- a/internal/eventbus/notification_event_bus.go
+++ b/internal/eventbus/notification_event_bus.go
@@ -10,79 +10,83 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+const (
+	pushNotificationRoutingKey    = "gossip-monger.notification.requested"
+	expectedNotificationEventType = "notification.requested"
+)
+
 // NotificationEventBus provides a type-safe API for notification events.
 type NotificationEventBus struct {
 	bus                      EventBus
 	logger                   *slog.Logger
-	pool                     *pgxpool.Pool
 	notificationEventHandler *NotificationEventHandler
-	onesignalClient          *onesignal.APIClient
+
+	// ctx is a long-lived context owned by NotificationEventBus, used by
+	// subscriber handlers. It is independent of any caller context so that
+	// handlers remain active for the lifetime of the bus.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewNotificationEventBus creates a new NotificationEventBus instance.
 func NewNotificationEventBus(
-	bus EventBus, pool *pgxpool.Pool,
+	bus EventBus,
+	pool *pgxpool.Pool,
 	onesignalClient *onesignal.APIClient,
 	logger *slog.Logger,
 ) *NotificationEventBus {
-
-	notificationEventHandler := NewNotificationEventHandler(pool, onesignalClient, logger)
-
-	b := &NotificationEventBus{
+	ctx, cancel := context.WithCancel(context.Background())
+	return &NotificationEventBus{
 		bus:                      bus,
-		pool:                     pool,
 		logger:                   logger,
-		notificationEventHandler: notificationEventHandler,
-		onesignalClient:          onesignalClient,
+		notificationEventHandler: NewNotificationEventHandler(pool, onesignalClient, logger),
+		ctx:                      ctx,
+		cancel:                   cancel,
 	}
-
-	return b
 }
 
-// SetupEventSubscriptions sets up all event subscriptions for the application
-func (b *NotificationEventBus) SetupEventSubscriptions(ctx context.Context) error {
-	// Subscribe to user created events
-	if err := b.SubscribePushNotificationRequested(
-		ctx,
-		b.notificationEventHandler.HandlerPushNotificationSendRequested,
-	); err != nil {
-		return fmt.Errorf("failed to subscribe to notification push  events: %w", err)
+// SetupEventSubscriptions registers all event subscriptions for the application.
+func (b *NotificationEventBus) SetupEventSubscriptions() error {
+	if err := b.subscribePushNotificationRequested(); err != nil {
+		return fmt.Errorf("failed to subscribe to notification push events: %w", err)
 	}
-	b.logger.Info("Gossip notification subscriptions set up successfully")
+	b.logger.Info("notification event subscriptions set up successfully")
 	return nil
 }
 
-// SubscribePushNotificationRequested listens for services requesting push notifications
-// to users
-// It handles unmarshaling and passes a typed struct to the handler.
-func (b *NotificationEventBus) SubscribePushNotificationRequested(ctx context.Context,
-	handler func(context context.Context, event NotificationEvent),
-) error {
-	// Use the same routing key as the publisher
-	routingKey := "gossip-monger.notification.requested"
+// Close cancels the internal context, signalling all active handlers to stop.
+func (b *NotificationEventBus) Close() {
+	b.cancel()
+}
 
-	// Subscribe to the generic event bus, and wrap the handler to unmarshal the data
-	return b.bus.Subscribe(routingKey, func(data []byte) {
+// subscribePushNotificationRequested listens for services requesting push
+// notifications to be sent to users.
+func (b *NotificationEventBus) subscribePushNotificationRequested() error {
+	return b.bus.Subscribe(pushNotificationRoutingKey, func(data []byte) {
 		var event NotificationEvent
 		if err := json.Unmarshal(data, &event); err != nil {
-			// Log the error but don't stop the consumer
-			// A dead-letter queue or logging service could be used here
-			b.logger.Error("Error unmarshalling data", slog.Any("error", err))
+			b.logger.Error("failed to unmarshal notification event",
+				slog.String("routing_key", pushNotificationRoutingKey),
+				slog.Any("error", err),
+			)
 			return
 		}
 
-		if event.Metadata.EventType != "notification.requested" {
-			b.logger.Error(fmt.Sprintf(
-				"Wrong metadata event type expected notification.requested instead got %s",
-				event.Metadata.EventType,
-			),
-				slog.String("requested", "notification.requested"),
-				// slog.String("hello", event.User.ID.String()),
-				/// Log that the operation was aborted by the service to maintain consistency
+		if event.Metadata.EventType != expectedNotificationEventType {
+			b.logger.Error("notification event rejected: unexpected event type",
+				slog.String("routing_key", pushNotificationRoutingKey),
+				slog.String("expected_event_type", expectedNotificationEventType),
+				slog.String("actual_event_type", event.Metadata.EventType),
 				slog.Bool("abort", true),
 			)
 			return
 		}
-		handler(ctx, event)
+
+		b.notificationEventHandler.HandlerPushNotificationSendRequested(b.ctx, event)
+
+		b.logger.Info("notification event handled successfully",
+			slog.String("event_type", event.Metadata.EventType),
+		)
 	})
 }
+

--- a/internal/eventbus/user_event_bus.go
+++ b/internal/eventbus/user_event_bus.go
@@ -9,56 +9,67 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+const userEventsRoutingKey = "verisafe.user.events"
+const expectedSourceServiceID = "io.opencrafts.verisafe"
+
 // UserEventBus provides a type-safe API for user events.
 type UserEventBus struct {
 	bus              EventBus
 	logger           *slog.Logger
 	pool             *pgxpool.Pool
 	userEventHandler *UserEventHandler
+
+	// ctx is a long-lived context owned by UserEventBus, used by subscriber
+	// handlers. It is independent of any caller context so that subscription
+	// handlers remain active for the lifetime of the bus.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewUserEventBus creates a new UserEventBus instance.
 func NewUserEventBus(bus EventBus, pool *pgxpool.Pool, logger *slog.Logger) *UserEventBus {
-
-	userEventHandler := NewUserEventHandler(pool, logger)
-
-	b := &UserEventBus{
+	ctx, cancel := context.WithCancel(context.Background())
+	return &UserEventBus{
 		bus:              bus,
 		pool:             pool,
 		logger:           logger,
-		userEventHandler: userEventHandler,
+		userEventHandler: NewUserEventHandler(pool, logger),
+		ctx:              ctx,
+		cancel:           cancel,
 	}
-
-	return b
 }
 
-// SetupEventSubscriptions sets up all event subscriptions for the application
-func (b *UserEventBus) SetupEventSubscriptions(ctx context.Context) error {
-	if err := b.SubscribeForUserEvents(ctx); err != nil {
+// SetupEventSubscriptions registers all event subscriptions for the specific event bus.
+func (b *UserEventBus) SetupEventSubscriptions() error {
+	if err := b.subscribeForUserEvents(); err != nil {
 		return fmt.Errorf("failed to subscribe to user events: %w", err)
 	}
-
-	b.logger.Info("Verisafe user event subscriptions set up successfully")
+	b.logger.Info("user event subscriptions set up successfully")
 	return nil
 }
 
-func (b *UserEventBus) SubscribeForUserEvents(ctx context.Context) error {
-	routingKey := "verisafe.user.events"
-	return b.bus.Subscribe(routingKey, func(data []byte) {
+// Close cancels the internal context, signalling all active handlers to stop.
+func (b *UserEventBus) Close() {
+	b.cancel()
+}
+
+func (b *UserEventBus) subscribeForUserEvents() error {
+	return b.bus.Subscribe(userEventsRoutingKey, func(data []byte) {
 		var event UserEvent
 		if err := json.Unmarshal(data, &event); err != nil {
-			// Log the error but don't stop the consumer
-			// A dead-letter queue or logging service could be used here
+			b.logger.Error("failed to unmarshal user event",
+				slog.String("routing_key", userEventsRoutingKey),
+				slog.Any("error", err),
+			)
 			return
 		}
-		if event.Metadata.SourceServiceID != "io.opencrafts.verisafe" {
-			b.logger.Error(fmt.Sprintf(
-				"Wrong metadata event service source id expected 'io.opencrafts.verisafe' instead got %s",
-				event.Metadata.SourceServiceID,
-			),
-				slog.String("requested", "user.created"),
+
+		if event.Metadata.SourceServiceID != expectedSourceServiceID {
+			b.logger.Error("user event rejected: unexpected source service ID",
+				slog.String("routing_key", userEventsRoutingKey),
+				slog.String("expected_source", expectedSourceServiceID),
+				slog.String("actual_source", event.Metadata.SourceServiceID),
 				slog.String("user_id", event.User.ID.String()),
-				/// Log that the operation was aborted by the service to maintain consistency
 				slog.Bool("abort", true),
 			)
 			return
@@ -66,30 +77,24 @@ func (b *UserEventBus) SubscribeForUserEvents(ctx context.Context) error {
 
 		switch event.Metadata.EventType {
 		case "user.created":
-			b.userEventHandler.HandleUserCreated(ctx, event)
-			break
-
+			b.userEventHandler.HandleUserCreated(b.ctx, event)
 		case "user.updated":
-			b.userEventHandler.HandleUserUpdated(ctx, event)
-			break
-
+			b.userEventHandler.HandleUserUpdated(b.ctx, event)
 		case "user.deleted":
-			b.userEventHandler.HandleUserDeleted(ctx, event)
-			break
+			b.userEventHandler.HandleUserDeleted(b.ctx, event)
 		default:
-			b.logger.Error(fmt.Sprintf(
-				"Wrong metadata event type expected user.created instead got %s",
-				event.Metadata.EventType,
-			),
-				slog.String("requested", "user.created"),
+			b.logger.Error("user event rejected: unrecognised event type",
+				slog.String("routing_key", userEventsRoutingKey),
+				slog.String("event_type", event.Metadata.EventType),
 				slog.String("user_id", event.User.ID.String()),
-				/// Log that the operation was aborted by the service to maintain consistency
 				slog.Bool("abort", true),
 			)
 			return
-
 		}
 
-		b.logger.Info("User event handled successfully", slog.Any("event", event))
+		b.logger.Info("user event handled successfully",
+			slog.String("event_type", event.Metadata.EventType),
+			slog.String("user_id", event.User.ID.String()),
+		)
 	})
 }


### PR DESCRIPTION
…gging

- Use amqp.DialConfig with explicit 10s heartbeat to prevent silent TCP drops
- Create dedicated publish channel separate from consumer channels
- Open a new channel per subscriber (RabbitMQ best practice, prevents concurrent channel use which caused silent closures)
- Add reconnectLoop watching conn.NotifyClose to automatically reconnect and replay all subscriptions on connection loss
- Set autoDelete: false on queues to survive consumer disconnects
- Protect shared state (conn, publishCh, subscriptions) with sync.RWMutex
- Add graceful shutdown via done channel signalling all consumer goroutines
- Accept *slog.Logger in NewRabbitMQEventBus and replace all log.Printf calls with structured slog attributes

- Own a long-lived context.Background() in each event bus instead of capturing the caller's startup context, preventing handler failures after the caller's context expires
- Add Close() to each event bus to cancel the internal context on shutdown
- Drop ctx parameter from SetupEventSubscriptions (no longer needed)
- Collapse exported handler-accepting Subscribe methods into unexported methods called directly with the known handler (single responsibility)
- Remove redundant client/pool fields from bus structs where only the handler needs them
- Replace fmt.Sprintf inside slog calls with static messages and typed slog attributes (String, Any, Bool) for clean JSON output
- Log previously swallowed unmarshal errors with routing_key and error attrs
- Replace slog.Any('event', event) success log with specific fields to avoid dumping sensitive data
- Extract routing keys, event types, and source IDs as package constants
- Remove redundant break statements from switch cases
- Log and return srv.Shutdown error instead of discarding it
- Call bus Close() methods in shutdown sequence after srv.Shutdown