### PR TITLE
Feat/notification resilience

### DIFF
--- a/database/migrations/20260712100000_add_notification_queue_message_id.sql
+++ b/database/migrations/20260712100000_add_notification_queue_message_id.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+SELECT 'up SQL query';
+-- +goose StatementEnd
+
+ALTER TABLE notifications ADD COLUMN queue_message_id TEXT;
+ALTER TABLE notifications ADD CONSTRAINT notifications_queue_message_id_key UNIQUE (queue_message_id);
+
+-- +goose Down
+-- +goose StatementBegin
+SELECT 'down SQL query';
+-- +goose StatementEnd
+
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_queue_message_id_key;
+ALTER TABLE notifications DROP COLUMN IF EXISTS queue_message_id;

--- a/database/queries/emails.sql
+++ b/database/queries/emails.sql
@@ -1,7 +1,11 @@
--- name: CreateEmailRequest :one
--- Persists an email request to the database for replayability
+-- name: UpsertEmailRequest :one
+-- Persists an email request to the database for replayability, or updates
+-- it in place if this is a retry of the same queue_message_id (dead-lettered
+-- redelivery) — retrying must not hit the queue_message_id UNIQUE
+-- constraint as a fresh insert, or the retry mechanism would just fail
+-- forever on the second attempt without ever reaching Resend again.
 INSERT INTO email_requests (
-  service_id, 
+  service_id,
   queue_message_id,
   exchange,
   routing_key,
@@ -23,8 +27,23 @@ INSERT INTO email_requests (
   processed_at
 
 ) VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+ON CONFLICT (queue_message_id) DO UPDATE SET
+  status = EXCLUDED.status,
+  processed_at = EXCLUDED.processed_at
 RETURNING *;
 
+
+-- name: GetEmailRequestByQueueMessageID :one
+-- Used to detect a duplicate send before calling Resend: if a request with
+-- this queue_message_id was already dispatched, the caller must skip
+-- resending rather than upsert-and-retry, or a legitimate DLX redelivery
+-- and an external duplicate republish become indistinguishable and both
+-- would trigger a second real send.
+select *
+from email_requests
+where queue_message_id = $1
+limit 1
+;
 
 -- name: GetEmailRequestByService :many
 -- Orders the time it was recieved ie the most previous

--- a/database/queries/notifications.sql
+++ b/database/queries/notifications.sql
@@ -1,4 +1,9 @@
--- name: CreateNotification :one
+-- name: UpsertNotification :one
+-- Inserts a notification send attempt, or updates it in place if this is a
+-- retry of the same queue_message_id (dead-lettered redelivery). Keeping one
+-- row per logical send, updated across attempts, matches how this table
+-- already behaves (a single mutable outcome row, not an attempt-history
+-- table like email_requests/email_dispatches).
 INSERT INTO notifications (
     app_id,
     included_segments,
@@ -52,14 +57,81 @@ INSERT INTO notifications (
     onesignal_notification_id,
     onesignal_status,
     onesignal_response,
-    onesignal_error
- 
+    onesignal_error,
+    queue_message_id,
+    status
+
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
     $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39,
-    $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53 
+    $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55
 )
+ON CONFLICT (queue_message_id) DO UPDATE SET
+    app_id = EXCLUDED.app_id,
+    included_segments = EXCLUDED.included_segments,
+    excluded_segments = EXCLUDED.excluded_segments,
+    include_player_ids = EXCLUDED.include_player_ids,
+    include_external_user_ids = EXCLUDED.include_external_user_ids,
+    include_email_tokens = EXCLUDED.include_email_tokens,
+    include_phone_numbers = EXCLUDED.include_phone_numbers,
+    include_ios_tokens = EXCLUDED.include_ios_tokens,
+    include_wp_wns_uris = EXCLUDED.include_wp_wns_uris,
+    include_amazon_reg_ids = EXCLUDED.include_amazon_reg_ids,
+    include_chrome_reg_ids = EXCLUDED.include_chrome_reg_ids,
+    include_chrome_web_reg_ids = EXCLUDED.include_chrome_web_reg_ids,
+    include_android_reg_ids = EXCLUDED.include_android_reg_ids,
+    contents = EXCLUDED.contents,
+    headings = EXCLUDED.headings,
+    subtitle = EXCLUDED.subtitle,
+    big_picture = EXCLUDED.big_picture,
+    large_icon = EXCLUDED.large_icon,
+    small_icon = EXCLUDED.small_icon,
+    ios_attachments = EXCLUDED.ios_attachments,
+    android_channel_id = EXCLUDED.android_channel_id,
+    android_accent_color = EXCLUDED.android_accent_color,
+    android_led_color = EXCLUDED.android_led_color,
+    android_group = EXCLUDED.android_group,
+    android_group_message = EXCLUDED.android_group_message,
+    android_sound = EXCLUDED.android_sound,
+    ios_sound = EXCLUDED.ios_sound,
+    wp_wns_sound = EXCLUDED.wp_wns_sound,
+    adm_sound = EXCLUDED.adm_sound,
+    chrome_web_image = EXCLUDED.chrome_web_image,
+    chrome_web_icon = EXCLUDED.chrome_web_icon,
+    chrome_web_badge = EXCLUDED.chrome_web_badge,
+    chrome_web_color = EXCLUDED.chrome_web_color,
+    chrome_web_sound = EXCLUDED.chrome_web_sound,
+    url = EXCLUDED.url,
+    web_url = EXCLUDED.web_url,
+    app_url = EXCLUDED.app_url,
+    data = EXCLUDED.data,
+    filters = EXCLUDED.filters,
+    tags = EXCLUDED.tags,
+    send_after = EXCLUDED.send_after,
+    delayed_option = EXCLUDED.delayed_option,
+    delivery_time_of_day = EXCLUDED.delivery_time_of_day,
+    ttl = EXCLUDED.ttl,
+    priority = EXCLUDED.priority,
+    target_user_id = EXCLUDED.target_user_id,
+    source_service_id = EXCLUDED.source_service_id,
+    source_user_id = EXCLUDED.source_user_id,
+    notification_type = EXCLUDED.notification_type,
+    onesignal_notification_id = EXCLUDED.onesignal_notification_id,
+    onesignal_status = EXCLUDED.onesignal_status,
+    onesignal_response = EXCLUDED.onesignal_response,
+    onesignal_error = EXCLUDED.onesignal_error,
+    status = EXCLUDED.status,
+    updated_at = NOW()
 RETURNING *;
+
+-- name: GetNotificationByQueueMessageID :one
+-- Used to detect a duplicate send before calling OneSignal: if a
+-- notification with this queue_message_id was already sent, the caller
+-- must skip resending rather than upsert-and-retry, or a legitimate DLX
+-- redelivery and an external duplicate republish become indistinguishable
+-- and both would trigger a second real send.
+SELECT * FROM notifications
+WHERE queue_message_id = $1;
 
 -- name: GetNotificationByID :one
 SELECT * FROM notifications 

--- a/docs/adrs/0006-add-circuit-breaker-and-dead-letter-retry-for-third-party-notification-providers.md
+++ b/docs/adrs/0006-add-circuit-breaker-and-dead-letter-retry-for-third-party-notification-providers.md
@@ -1,0 +1,36 @@
+# 6. Add circuit breaker and dead-letter retry for third-party notification providers
+
+Date: 2026-07-12
+
+## Status
+
+accepted
+
+## Context
+
+Verified directly in code that a transient Resend/OneSignal outage previously resulted in a message being silently, permanently lost:
+
+- `internal/broker/consumer.go`'s consume loop called `msg.Nack(false, false)` on any handler error, and the queues had no dead-letter exchange configured — RabbitMQ simply discarded the message. No DLQ, no backoff, no second attempt.
+- `internal/service/email_service.go`'s `Send` swallowed the Resend error — it recorded `status = "failed"` in the database, then **returned `nil`**, so the consumer `Ack`'d the message and it was gone. `docs/email_integration_guide.md` claimed automatic retry; that was aspirational and never actually implemented.
+- `internal/service/push_notification_service.go`'s `Send` returned early on a OneSignal error **before** any database row was ever written — worse than email's case, with zero audit trail for a failed push.
+- No circuit breaker existed anywhere, so a sustained outage meant every queued message still triggered a live, blocking HTTP call certain to fail, burning through consumer prefetch slots.
+
+## Decision
+
+Add a per-provider circuit breaker (`internal/resilience`, wrapping `sony/gobreaker/v2`) around the OneSignal and Resend calls, and pair it with RabbitMQ-native retry: the two provider queues now dead-letter into a shared `gossip.retry.exchange` on any handler error, land in `gossip.retry.queue` for a configurable delay (`RETRY_DELAY_SECONDS`), then RabbitMQ automatically redelivers them to their original queue. After `MAX_RETRY_ATTEMPTS` (tracked via RabbitMQ's own `x-death` header — no schema needed for that), a message is routed to `gossip.parked.queue` for manual triage instead of retried forever.
+
+Both services now persist every outcome — including `circuit_open` (the breaker rejected the call outright) and `failed` (the provider itself errored) — as a distinct status, and both `email_requests` and `notifications` are now upserted by `queue_message_id` rather than always inserted, so a dead-lettered redelivery updates the same row instead of hitting a unique-constraint violation on the second attempt (which would have silently defeated the whole retry mechanism).
+
+`internal/broker/publisher.go`'s previously-unused `Publisher`/`MessagePublisher` now has its first real caller: routing exhausted messages to the parked queue.
+
+Deliberately deferred, not forgotten:
+- Metrics/alerting on breaker state — no metrics stack exists in this service yet; breaker transitions are logged via `slog` only.
+- Multi-tier exponential backoff — one configurable fixed retry delay for v1.
+- Extending this DLX/retry pattern to `user_consumer.go` (Verisafe sync) — it doesn't call a third-party API, so it's a different failure mode and out of scope here.
+
+## Consequences
+
+- A provider outage now fails fast (breaker open) instead of piling up blocking HTTP calls, and a failed send gets several automatic retries with a delay before landing somewhere a human can see it — the two problems ("silently fails", "no retry policy") this ADR was written to fix.
+- Operators can now distinguish, per attempt: `circuit_open` (we didn't even try, provider already known-down), `failed` (we tried and the provider rejected it or errored), and `sent`/`dispatched` (success) — previously push had no record of failures at all, and email conflated "failed" with what is now split out as `circuit_open`.
+- Retrying via requeue means idempotency now matters where it didn't structurally before: `CreateEmailRequest`/`CreateNotification` becoming `UpsertEmailRequest`/`UpsertNotification` is a load-bearing part of this change, not incidental — removing the upsert behavior while keeping DLX retry would reintroduce silent failure via unique-constraint errors on every redelivery.
+- New operational surface: three new RabbitMQ queues/exchanges to monitor (`gossip.retry.queue` depth indicates ongoing trouble; `gossip.parked.queue` depth indicates messages needing manual attention), and five new environment variables (`RETRY_DELAY_SECONDS`, `MAX_RETRY_ATTEMPTS`, `BREAKER_CONSECUTIVE_FAILURES`, `BREAKER_OPEN_TIMEOUT_SECONDS`, `BREAKER_HALF_OPEN_MAX_REQUESTS`), all with defaults so no operator action was required to adopt this.

--- a/docs/email_integration_guide.md
+++ b/docs/email_integration_guide.md
@@ -27,7 +27,7 @@ Your service publishes a JSON message to the RabbitMQ topic exchange. Gossip Mon
 - **Routing key:** `gossip.emails.send`
 - **Exchange type:** Topic
 
-If the dispatch fails (e.g. Resend returns an error), Gossip Monger will mark the request as failed and retry it automatically when the system is free. There is no guaranteed retry time. **Do not republish the same message to force a retry** — if you publish again using the same `request_id`, it will be rejected automatically due to idempotency checks.
+If the dispatch fails (e.g. Resend returns an error, or Resend is down and Gossip Monger's circuit breaker is protecting it from being hammered further), Gossip Monger marks the request accordingly and retries it automatically, with a delay, up to a configured number of attempts — you don't need to do anything. There is no guaranteed retry time. **Do not republish the same message to force a retry** — if you publish again using the same `request_id` while the original is still retrying or already dispatched, Gossip Monger will recognize it as the same logical send and will not dispatch it a second time.
 
 ---
 
@@ -377,11 +377,12 @@ Invalid because `content` is missing. Gossip Monger will fail to parse the attac
 
 ## Idempotency and Retries
 
-Every message requires a unique `request_id` (UUID). Gossip Monger uses this to prevent duplicate processing.
+Every message requires a unique `request_id` (UUID). Gossip Monger uses this as the idempotency key for the whole lifecycle of a send, not just the first attempt.
 
-- **If a message is processed successfully**, publishing the same `request_id` again will be rejected
-- **If a message fails** (e.g. Resend returns an error), Gossip Monger will retry it automatically. Do not republish — doing so with the same `request_id` will fail, and with a new `request_id` will result in a duplicate send attempt once the original retry also goes through
-- Generate a fresh UUID per send event, not per session or per user
+- **If a message was already dispatched successfully**, publishing the same `request_id` again is a safe no-op — Gossip Monger recognizes it and will not send a second email.
+- **If a message fails** (provider error, or the circuit breaker is open because Resend looks down), Gossip Monger retries it automatically with a delay, up to a configured number of attempts, before routing it to a queue for manual review. You do not need to republish it.
+- **Do not republish with a new `request_id`** to "make sure it goes through" — Gossip Monger has no way to know it's the same logical email, and you will get a duplicate send once the original attempt (or its automatic retry) also completes.
+- Generate a fresh UUID per send event, not per session or per user.
 
 ---
 
@@ -402,3 +403,4 @@ If something goes wrong and you suspect emails are being sent unintentionally, c
 
 - [ADR-0003: Auto-register services on first email send](adrs/0003-auto-register-services-on-first-email-send.md) — why `source_service_id` no longer needs pre-registration
 - [ADR-0004: Externalize allowed email sender domains to configuration](adrs/0004-externalize-allowed-email-sender-domains-to-configuration.md) — why the sending domain is configurable rather than fixed in code
+- [ADR-0006: Add circuit breaker and dead-letter retry for third-party notification providers](adrs/0006-add-circuit-breaker-and-dead-letter-retry-for-third-party-notification-providers.md) — why a failed send is retried automatically instead of silently dropped

--- a/docs/push_notification_integration.md
+++ b/docs/push_notification_integration.md
@@ -51,7 +51,7 @@ Every message must be valid JSON with two top-level fields: `metadata` and `noti
 | `event_type`      | string | Yes      | Must be `"push.send"` for sending a notification                            |
 | `timestamp`       | string | Yes      | ISO 8601 timestamp of when your service produced the event                  |
 | `source_service_id` | string | Yes    | Your service's identifier. **Must start with `io.opencrafts.`**             |
-| `request_id`      | string | Yes      | A unique ID for this request, used for tracing and logging                  |
+| `request_id`      | string | Yes      | A unique ID for this request. Doubles as the idempotency key — see [Retries](#retries) below |
 
 ### `notification` fields
 
@@ -302,9 +302,19 @@ The simplest possible notification — a heading, body, and a target user.
 
 ---
 
+## Retries
+
+`request_id` is your idempotency key for the whole lifecycle of a send, not just the first attempt.
+
+- **If a push was already sent successfully**, publishing the same `request_id` again is a safe no-op — Gossip Monger recognizes it and will not send a second push.
+- **If a send fails** (OneSignal error, or the circuit breaker is open because OneSignal looks down), Gossip Monger retries it automatically with a delay, up to a configured number of attempts, before routing it to a queue for manual review. You do not need to republish it.
+- **Do not republish with a new `request_id`** to "make sure it goes through" — Gossip Monger has no way to know it's the same logical push, and you will get a duplicate send once the original attempt (or its automatic retry) also completes.
+- Generate a fresh UUID per send event, not per session or per user.
+
+---
+
 ## Notes
 
 - The `app_id` field on the notification object is ignored. The service uses its own configured OneSignal app ID (see [ADR-0005](adrs/0005-defer-per-service-onesignal-app-and-api-key-routing.md)).
 - `target_user_id`/`source_user_id` are not validated against any internal user directory — they are recorded as-is and forwarded to OneSignal as external-id aliases (see [ADR-0001](adrs/0001-drop-foreign-key-from-notifications-to-local-users-table.md)). There is no pre-registration step for `source_service_id` on push, same as before.
-- Successful and failed notifications are both persisted, including the raw OneSignal response and any error details.
-- `request_id` is used for tracing only — include a unique value per message to make debugging easier.
+- Every attempt is persisted, including breaker-rejected and provider-error outcomes, not just successes — see [ADR-0006](adrs/0006-add-circuit-breaker-and-dead-letter-retry-for-third-party-notification-providers.md).

--- a/example.env
+++ b/example.env
@@ -24,6 +24,13 @@ RABBITMQ_USER=guest
 RABBITMQ_PASSWORD=guest
 RABBITMQ_ADDRESS=localhost
 RABBITMQ_PORT=5672
+RETRY_DELAY_SECONDS=30
+MAX_RETRY_ATTEMPTS=5
+
+# Circuit breaker configuration (applies to both OneSignal and Resend calls)
+BREAKER_CONSECUTIVE_FAILURES=5
+BREAKER_OPEN_TIMEOUT_SECONDS=30
+BREAKER_HALF_OPEN_MAX_REQUESTS=1
 
 # OneSignal configuration
 ONESIGNAL_APP_ID=your-onesignal-app-id

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
+	github.com/sony/gobreaker/v2 v2.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/opencrafts-io/gossip-monger/internal/config"
 	"github.com/opencrafts-io/gossip-monger/internal/middleware"
 	"github.com/opencrafts-io/gossip-monger/internal/repository"
+	"github.com/opencrafts-io/gossip-monger/internal/resilience"
 	"github.com/opencrafts-io/gossip-monger/internal/service"
 	"github.com/resend/resend-go/v3"
 )
@@ -95,11 +96,20 @@ func NewGossipMongerApp(
 		panic("Failed to initialize one signal service")
 
 	}
+	breakerSettings := resilience.Settings{
+		ConsecutiveFailures: cfg.BreakerConfig.ConsecutiveFailures,
+		OpenTimeout: time.Duration(
+			cfg.BreakerConfig.OpenTimeoutSeconds,
+		) * time.Second,
+		HalfOpenMaxRequests: cfg.BreakerConfig.HalfOpenMaxRequests,
+	}
+
 	querier := repository.New(connPool)
 	pnsvc := service.NewPushNotificationService(
 		querier,
 		logger,
 		oneSignalService,
+		breakerSettings,
 	)
 
 	resendClient := resend.NewClient(cfg.ResendConfig.ResendAPIKey)
@@ -108,6 +118,7 @@ func NewGossipMongerApp(
 		connPool,
 		resendClient,
 		cfg.ResendConfig.AllowedSenderDomains,
+		breakerSettings,
 		logger,
 	)
 
@@ -177,9 +188,28 @@ func (gm *GossipMonger) Start(ctx context.Context) error {
 }
 
 func (gm *GossipMonger) startConsumers(ctx context.Context) {
+	retryDelay := time.Duration(
+		gm.config.RabbitMQConfig.RetryDelaySeconds,
+	) * time.Second
+
+	if err := broker.DeclareRetryTopology(
+		gm.rabbitMQConn,
+		retryDelay,
+		"gossip.topic.exchange",
+		[]string{"gossip.emails.send", "gossip.push.send"},
+	); err != nil {
+		gm.logger.Error(
+			"failed to declare retry topology, failed sends will not be retried",
+			slog.Any("error", err),
+		)
+	}
+
+	maxRetryAttempts := gm.config.RabbitMQConfig.MaxRetryAttempts
+
 	pushNotificationConsumer := consumers.NewPushNotificationConsumer(
 		gm.rabbitMQConn,
 		gm.pushNotificationSvc,
+		maxRetryAttempts,
 		gm.logger,
 	)
 
@@ -192,6 +222,7 @@ func (gm *GossipMonger) startConsumers(ctx context.Context) {
 	emailConsumer := consumers.NewEmailConsumer(
 		gm.rabbitMQConn,
 		gm.emailService,
+		maxRetryAttempts,
 		gm.logger,
 	)
 

--- a/internal/broker/consumer.go
+++ b/internal/broker/consumer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 type ExchangeType string
@@ -25,39 +27,53 @@ type MessageConsumer interface {
 		exchangeType ExchangeType,
 		queue string,
 		bindingKey string,
+		deadLetterExchange string,
 		handler MessageHandler,
 	) error
 }
 
 // Consumer implements MessageConsumer
 type Consumer struct {
-	conn          Connection
-	prefetchCount int
-	logger        slog.Logger
+	conn             Connection
+	prefetchCount    int
+	maxRetryAttempts int
+	logger           slog.Logger
 }
 
 // NewConsumer creates a new Consumer instance with configurable prefetch count
 // prefetchCount limits the number of unacknowledged messages delivered to this consumer
 // Recommended: 1 for serial processing, higher for parallel processing
+//
+// maxRetryAttempts only matters for queues declared with a deadLetterExchange
+// (see Consume) — it's ignored otherwise.
 func NewConsumer(
 	conn Connection,
 	prefetchCount int,
+	maxRetryAttempts int,
 	logger slog.Logger,
 ) *Consumer {
 	return &Consumer{
-		conn:          conn,
-		prefetchCount: prefetchCount,
-		logger:        logger,
+		conn:             conn,
+		prefetchCount:    prefetchCount,
+		maxRetryAttempts: maxRetryAttempts,
+		logger:           logger,
 	}
 }
 
-// Consume starts consuming messages from a queue and passes them to the handler
+// Consume starts consuming messages from a queue and passes them to the
+// handler. If deadLetterExchange is non-empty, the queue is declared with
+// it as its x-dead-letter-exchange, and a handler error nacks the message
+// there (instead of discarding it) for automatic delayed redelivery — up to
+// maxRetryAttempts, after which it is routed to the parked queue instead of
+// being nacked again. Pass "" to keep the original discard-on-error
+// behavior (no DLX configured).
 func (c *Consumer) Consume(
 	ctx context.Context,
 	exchange string,
 	exchangeType ExchangeType,
 	queue string,
 	bindingKey string,
+	deadLetterExchange string,
 	handler MessageHandler,
 ) error {
 	ch := c.conn.Channel()
@@ -80,13 +96,18 @@ func (c *Consumer) Consume(
 		return fmt.Errorf("failed to declare exchange: %w", err)
 	}
 
+	var queueArgs amqp.Table
+	if deadLetterExchange != "" {
+		queueArgs = amqp.Table{"x-dead-letter-exchange": deadLetterExchange}
+	}
+
 	_, err = ch.QueueDeclare(
-		queue, // name
-		true,  // durable (recommended)
-		false, // delete when unused
-		false, // exclusive
-		false, // no-wait
-		nil,   // arguments
+		queue,     // name
+		true,      // durable (recommended)
+		false,     // delete when unused
+		false,     // exclusive
+		false,     // no-wait
+		queueArgs, // arguments
 	)
 	if err != nil {
 		return fmt.Errorf("failed to declare queue: %w", err)
@@ -155,11 +176,73 @@ func (c *Consumer) Consume(
 					"queue", queue,
 					"error", err,
 				)
-				msg.Nack(false, false)
+
+				if deadLetterExchange != "" && deathCount(msg.Headers) >= c.maxRetryAttempts {
+					if parkErr := c.park(ctx, msg.Body); parkErr != nil {
+						c.logger.Error("failed to park exhausted message, retrying instead",
+							"queue", queue,
+							"error", parkErr,
+						)
+						msg.Nack(false, false)
+					} else {
+						c.logger.Warn("message exhausted retry attempts, parked for manual triage",
+							"queue", queue,
+							"attempts", c.maxRetryAttempts,
+						)
+						msg.Ack(false)
+					}
+				} else {
+					msg.Nack(false, false)
+					// With a dead-letter-exchange configured, this is not a
+					// discard — RabbitMQ routes it into the retry flow.
+				}
 				// Continue consuming, don't stop on handler error
 			} else {
 				msg.Ack(false)
 			}
 		}
 	}
+}
+
+// park republishes body verbatim to the parked queue, for a message that
+// has exhausted its retry attempts and needs manual triage rather than
+// another automatic redelivery.
+func (c *Consumer) park(ctx context.Context, body []byte) error {
+	publisher := NewPublisher(c.conn, &c.logger)
+	return publisher.PublishRaw(ctx, "", ParkedQueue, body)
+}
+
+// deathCount returns how many times this message has previously been
+// dead-lettered for handler rejection (RabbitMQ's "rejected" reason),
+// derived from the standard x-death header. Redelivery cycles caused by the
+// retry queue's TTL expiry ("expired" reason) are not counted here — those
+// happen once per rejection and would otherwise double the count.
+func deathCount(headers amqp.Table) int {
+	raw, ok := headers["x-death"]
+	if !ok {
+		return 0
+	}
+
+	deaths, ok := raw.([]any)
+	if !ok {
+		return 0
+	}
+
+	total := 0
+	for _, d := range deaths {
+		entry, ok := d.(amqp.Table)
+		if !ok {
+			continue
+		}
+		if reason, _ := entry["reason"].(string); reason != "rejected" {
+			continue
+		}
+		switch count := entry["count"].(type) {
+		case int64:
+			total += int(count)
+		case int32:
+			total += int(count)
+		}
+	}
+	return total
 }

--- a/internal/broker/consumers/email_consumer.go
+++ b/internal/broker/consumers/email_consumer.go
@@ -20,10 +20,11 @@ type EmailConsumer struct {
 func NewEmailConsumer(
 	conn broker.Connection,
 	emailService service.EmailService,
+	maxRetryAttempts int,
 	logger *slog.Logger,
 ) *EmailConsumer {
 	return &EmailConsumer{
-		consumer:     broker.NewConsumer(conn, 10, *logger),
+		consumer:     broker.NewConsumer(conn, 10, maxRetryAttempts, *logger),
 		emailService: emailService,
 		logger:       logger,
 	}
@@ -36,6 +37,7 @@ func (ec *EmailConsumer) Start(ctx context.Context) error {
 		broker.TopicExchangeType,
 		"gossip.emails.queue",
 		"gossip.emails.*",
+		broker.RetryExchange,
 		ec.handleMessage,
 	)
 }

--- a/internal/broker/consumers/push_notification_consumer.go
+++ b/internal/broker/consumers/push_notification_consumer.go
@@ -20,10 +20,11 @@ type PushNotificationConsumer struct {
 func NewPushNotificationConsumer(
 	conn broker.Connection,
 	notificationService service.PushNotificationService,
+	maxRetryAttempts int,
 	logger *slog.Logger,
 ) *PushNotificationConsumer {
 	return &PushNotificationConsumer{
-		consumer:            broker.NewConsumer(conn, 10, *logger),
+		consumer:            broker.NewConsumer(conn, 10, maxRetryAttempts, *logger),
 		notificationService: notificationService,
 		logger:              logger,
 	}
@@ -36,6 +37,7 @@ func (pnc *PushNotificationConsumer) Start(ctx context.Context) error {
 		broker.TopicExchangeType,
 		"gossip.notification.queue",
 		"gossip.push.*",
+		broker.RetryExchange,
 		pnc.handleMessage,
 	)
 }
@@ -63,7 +65,11 @@ func (pnc *PushNotificationConsumer) handleMessage(
 
 	switch notifMsg.Metadata.EventType {
 	case "push.send":
-		return pnc.notificationService.Send(ctx, notifMsg.Notification)
+		return pnc.notificationService.Send(
+			ctx,
+			notifMsg.Notification,
+			notifMsg.Metadata.RequestID,
+		)
 	default:
 		pnc.logger.Error(
 			"Got wrong event metadata type",

--- a/internal/broker/consumers/user_consumer.go
+++ b/internal/broker/consumers/user_consumer.go
@@ -22,7 +22,9 @@ func NewUserConsumer(
 	logger *slog.Logger,
 ) *UserConsumer {
 	return &UserConsumer{
-		consumer:    broker.NewConsumer(conn, 10, *logger),
+		// No dead-letter exchange: user sync doesn't call a third-party API,
+		// so it keeps the original discard-on-error behavior.
+		consumer:    broker.NewConsumer(conn, 10, 0, *logger),
 		userService: userService,
 		logger:      logger,
 	}
@@ -35,6 +37,7 @@ func (uc *UserConsumer) Start(ctx context.Context) error {
 		broker.FanoutExchangeType,
 		"verisafe.user.queue",
 		"verisafe.user.*",
+		"",
 		uc.handleMessage,
 	)
 }

--- a/internal/broker/publisher.go
+++ b/internal/broker/publisher.go
@@ -16,6 +16,14 @@ type MessagePublisher interface {
 		exchange, routingKey string,
 		message any,
 	) error
+	// PublishRaw publishes body as-is, skipping JSON marshaling. Used to
+	// forward an already-serialized message body verbatim, e.g. re-publishing
+	// a dead-lettered delivery's raw bytes to the parked queue.
+	PublishRaw(
+		ctx context.Context,
+		exchange, routingKey string,
+		body []byte,
+	) error
 }
 
 // Publisher implements MessagePublisher
@@ -74,6 +82,46 @@ func (p *Publisher) Publish(
 	}
 
 	p.logger.Debug("message published",
+		"exchange", exchange,
+		"routing_key", routingKey,
+	)
+	return nil
+}
+
+// PublishRaw publishes body as-is, skipping JSON marshaling.
+func (p *Publisher) PublishRaw(
+	ctx context.Context,
+	exchange, routingKey string,
+	body []byte,
+) error {
+	ch := p.conn.Channel()
+	if ch == nil {
+		err := fmt.Errorf("channel is nil")
+		p.logger.Error("cannot publish message", "error", err)
+		return err
+	}
+
+	err := ch.PublishWithContext(
+		ctx,
+		exchange,
+		routingKey,
+		false, // mandatory
+		false, // immediate
+		amqp.Publishing{
+			ContentType: "application/json",
+			Body:        body,
+		},
+	)
+	if err != nil {
+		p.logger.Error("failed to publish raw message",
+			"exchange", exchange,
+			"routing_key", routingKey,
+			"error", err,
+		)
+		return fmt.Errorf("failed to publish raw message: %w", err)
+	}
+
+	p.logger.Debug("raw message published",
 		"exchange", exchange,
 		"routing_key", routingKey,
 	)

--- a/internal/broker/topology.go
+++ b/internal/broker/topology.go
@@ -1,0 +1,87 @@
+package broker
+
+import (
+	"fmt"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+const (
+	// RetryExchange is the shared dead-letter target for queues that want
+	// automatic delayed redelivery instead of losing a failed message.
+	RetryExchange = "gossip.retry.exchange"
+	// RetryQueue holds a dead-lettered message for its configured delay,
+	// then RabbitMQ redelivers it (via its own x-dead-letter-exchange) back
+	// to whichever queue its original routing key maps to.
+	RetryQueue = "gossip.retry.queue"
+	// ParkedQueue is the terminal destination for messages that exhausted
+	// their retry attempts. Never auto-consumed — for manual triage.
+	ParkedQueue = "gossip.parked.queue"
+)
+
+// DeclareRetryTopology declares the shared retry (delayed-requeue) queue and
+// the terminal parked queue used by consumers that opt into automatic
+// retry-with-backoff instead of dropping a failed message.
+//
+// sourceExchange is where a message is redelivered once its retry delay
+// elapses — the queues that dead-letter into RetryExchange must already be
+// bound to sourceExchange under the same routing keys passed here, or the
+// redelivered message has nowhere to land.
+func DeclareRetryTopology(
+	conn Connection,
+	retryDelay time.Duration,
+	sourceExchange string,
+	routingKeys []string,
+) error {
+	ch := conn.Channel()
+	if ch == nil {
+		return fmt.Errorf("channel is nil")
+	}
+
+	if err := ch.ExchangeDeclare(
+		RetryExchange,
+		string(DirectExchangeType),
+		true,  // durable
+		false, // auto-deleted
+		false, // internal
+		false, // no-wait
+		nil,   // arguments
+	); err != nil {
+		return fmt.Errorf("failed to declare retry exchange: %w", err)
+	}
+
+	_, err := ch.QueueDeclare(
+		RetryQueue,
+		true,  // durable
+		false, // delete when unused
+		false, // exclusive
+		false, // no-wait
+		amqp.Table{
+			"x-message-ttl":          int64(retryDelay / time.Millisecond),
+			"x-dead-letter-exchange": sourceExchange,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to declare retry queue: %w", err)
+	}
+
+	for _, key := range routingKeys {
+		if err := ch.QueueBind(RetryQueue, key, RetryExchange, false, nil); err != nil {
+			return fmt.Errorf("failed to bind retry queue for %q: %w", key, err)
+		}
+	}
+
+	if _, err := ch.QueueDeclare(
+		ParkedQueue,
+		true,  // durable
+		false, // delete when unused
+		false, // exclusive
+		false, // no-wait
+		nil,   // arguments
+	); err != nil {
+		return fmt.Errorf("failed to declare parked queue: %w", err)
+	}
+
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,22 @@ type Config struct {
 		RabbitMQPass    string `envconfig:"RABBITMQ_PASSWORD"`
 		RabbitMQAddress string `envconfig:"RABBITMQ_ADDRESS"`
 		RabbitMQPort    int    `envconfig:"RABBITMQ_PORT"`
+
+		// RetryDelaySeconds is how long a failed message waits in the
+		// retry queue before being redelivered to its original queue.
+		RetryDelaySeconds int `envconfig:"RETRY_DELAY_SECONDS" default:"30"`
+		// MaxRetryAttempts is how many times a message may be redelivered
+		// before it is routed to the parked queue for manual triage.
+		MaxRetryAttempts int `envconfig:"MAX_RETRY_ATTEMPTS" default:"5"`
+	}
+
+	// BreakerConfig configures the circuit breakers guarding calls to
+	// OneSignal and Resend. The same thresholds apply to both providers —
+	// nothing today suggests they need independent tuning.
+	BreakerConfig struct {
+		ConsecutiveFailures uint32 `envconfig:"BREAKER_CONSECUTIVE_FAILURES" default:"5"`
+		OpenTimeoutSeconds  int    `envconfig:"BREAKER_OPEN_TIMEOUT_SECONDS" default:"30"`
+		HalfOpenMaxRequests uint32 `envconfig:"BREAKER_HALF_OPEN_MAX_REQUESTS" default:"1"`
 	}
 
 	// OneSignal configuration

--- a/internal/repository/emails.sql.go
+++ b/internal/repository/emails.sql.go
@@ -59,74 +59,15 @@ func (q *Queries) CreateEmailDispatch(ctx context.Context, arg CreateEmailDispat
 	return i, err
 }
 
-const createEmailRequest = `-- name: CreateEmailRequest :one
-INSERT INTO email_requests (
-  service_id, 
-  queue_message_id,
-  exchange,
-  routing_key,
-
-  from_address,
-  reply_to,
-  to_addresses,
-  cc_addresses,
-  bcc_addresses,
-  subject,
-  body_html,
-  body_text,
-  attachments,
-
-  template_id,
-  template_vars,
-
-  status,
-  processed_at
-
-) VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
-RETURNING id, service_id, queue_message_id, exchange, routing_key, from_address, reply_to, to_addresses, cc_addresses, bcc_addresses, subject, body_html, body_text, attachments, template_id, template_vars, status, received_at, processed_at
+const getEmailRequestByID = `-- name: GetEmailRequestByID :one
+select id, service_id, queue_message_id, exchange, routing_key, from_address, reply_to, to_addresses, cc_addresses, bcc_addresses, subject, body_html, body_text, attachments, template_id, template_vars, status, received_at, processed_at
+from email_requests
+where id = $1
+limit 1
 `
 
-type CreateEmailRequestParams struct {
-	ServiceID      string          `json:"service_id"`
-	QueueMessageID string          `json:"queue_message_id"`
-	Exchange       string          `json:"exchange"`
-	RoutingKey     string          `json:"routing_key"`
-	FromAddress    string          `json:"from_address"`
-	ReplyTo        *string         `json:"reply_to"`
-	ToAddresses    []string        `json:"to_addresses"`
-	CcAddresses    []string        `json:"cc_addresses"`
-	BccAddresses   []string        `json:"bcc_addresses"`
-	Subject        string          `json:"subject"`
-	BodyHtml       *string         `json:"body_html"`
-	BodyText       *string         `json:"body_text"`
-	Attachments    json.RawMessage `json:"attachments"`
-	TemplateID     *string         `json:"template_id"`
-	TemplateVars   json.RawMessage `json:"template_vars"`
-	Status         string          `json:"status"`
-	ProcessedAt    *time.Time      `json:"processed_at"`
-}
-
-// Persists an email request to the database for replayability
-func (q *Queries) CreateEmailRequest(ctx context.Context, arg CreateEmailRequestParams) (EmailRequest, error) {
-	row := q.db.QueryRow(ctx, createEmailRequest,
-		arg.ServiceID,
-		arg.QueueMessageID,
-		arg.Exchange,
-		arg.RoutingKey,
-		arg.FromAddress,
-		arg.ReplyTo,
-		arg.ToAddresses,
-		arg.CcAddresses,
-		arg.BccAddresses,
-		arg.Subject,
-		arg.BodyHtml,
-		arg.BodyText,
-		arg.Attachments,
-		arg.TemplateID,
-		arg.TemplateVars,
-		arg.Status,
-		arg.ProcessedAt,
-	)
+func (q *Queries) GetEmailRequestByID(ctx context.Context, id uuid.UUID) (EmailRequest, error) {
+	row := q.db.QueryRow(ctx, getEmailRequestByID, id)
 	var i EmailRequest
 	err := row.Scan(
 		&i.ID,
@@ -152,15 +93,20 @@ func (q *Queries) CreateEmailRequest(ctx context.Context, arg CreateEmailRequest
 	return i, err
 }
 
-const getEmailRequestByID = `-- name: GetEmailRequestByID :one
+const getEmailRequestByQueueMessageID = `-- name: GetEmailRequestByQueueMessageID :one
 select id, service_id, queue_message_id, exchange, routing_key, from_address, reply_to, to_addresses, cc_addresses, bcc_addresses, subject, body_html, body_text, attachments, template_id, template_vars, status, received_at, processed_at
 from email_requests
-where id = $1
+where queue_message_id = $1
 limit 1
 `
 
-func (q *Queries) GetEmailRequestByID(ctx context.Context, id uuid.UUID) (EmailRequest, error) {
-	row := q.db.QueryRow(ctx, getEmailRequestByID, id)
+// Used to detect a duplicate send before calling Resend: if a request with
+// this queue_message_id was already dispatched, the caller must skip
+// resending rather than upsert-and-retry, or a legitimate DLX redelivery
+// and an external duplicate republish become indistinguishable and both
+// would trigger a second real send.
+func (q *Queries) GetEmailRequestByQueueMessageID(ctx context.Context, queueMessageID string) (EmailRequest, error) {
+	row := q.db.QueryRow(ctx, getEmailRequestByQueueMessageID, queueMessageID)
 	var i EmailRequest
 	err := row.Scan(
 		&i.ID,
@@ -257,6 +203,106 @@ type UpdateEmailRequestStatusByIDParams struct {
 // the predefined statuses
 func (q *Queries) UpdateEmailRequestStatusByID(ctx context.Context, arg UpdateEmailRequestStatusByIDParams) (EmailRequest, error) {
 	row := q.db.QueryRow(ctx, updateEmailRequestStatusByID, arg.ID, arg.Status)
+	var i EmailRequest
+	err := row.Scan(
+		&i.ID,
+		&i.ServiceID,
+		&i.QueueMessageID,
+		&i.Exchange,
+		&i.RoutingKey,
+		&i.FromAddress,
+		&i.ReplyTo,
+		&i.ToAddresses,
+		&i.CcAddresses,
+		&i.BccAddresses,
+		&i.Subject,
+		&i.BodyHtml,
+		&i.BodyText,
+		&i.Attachments,
+		&i.TemplateID,
+		&i.TemplateVars,
+		&i.Status,
+		&i.ReceivedAt,
+		&i.ProcessedAt,
+	)
+	return i, err
+}
+
+const upsertEmailRequest = `-- name: UpsertEmailRequest :one
+INSERT INTO email_requests (
+  service_id,
+  queue_message_id,
+  exchange,
+  routing_key,
+
+  from_address,
+  reply_to,
+  to_addresses,
+  cc_addresses,
+  bcc_addresses,
+  subject,
+  body_html,
+  body_text,
+  attachments,
+
+  template_id,
+  template_vars,
+
+  status,
+  processed_at
+
+) VALUES ( $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+ON CONFLICT (queue_message_id) DO UPDATE SET
+  status = EXCLUDED.status,
+  processed_at = EXCLUDED.processed_at
+RETURNING id, service_id, queue_message_id, exchange, routing_key, from_address, reply_to, to_addresses, cc_addresses, bcc_addresses, subject, body_html, body_text, attachments, template_id, template_vars, status, received_at, processed_at
+`
+
+type UpsertEmailRequestParams struct {
+	ServiceID      string          `json:"service_id"`
+	QueueMessageID string          `json:"queue_message_id"`
+	Exchange       string          `json:"exchange"`
+	RoutingKey     string          `json:"routing_key"`
+	FromAddress    string          `json:"from_address"`
+	ReplyTo        *string         `json:"reply_to"`
+	ToAddresses    []string        `json:"to_addresses"`
+	CcAddresses    []string        `json:"cc_addresses"`
+	BccAddresses   []string        `json:"bcc_addresses"`
+	Subject        string          `json:"subject"`
+	BodyHtml       *string         `json:"body_html"`
+	BodyText       *string         `json:"body_text"`
+	Attachments    json.RawMessage `json:"attachments"`
+	TemplateID     *string         `json:"template_id"`
+	TemplateVars   json.RawMessage `json:"template_vars"`
+	Status         string          `json:"status"`
+	ProcessedAt    *time.Time      `json:"processed_at"`
+}
+
+// Persists an email request to the database for replayability, or updates
+// it in place if this is a retry of the same queue_message_id (dead-lettered
+// redelivery) — retrying must not hit the queue_message_id UNIQUE
+// constraint as a fresh insert, or the retry mechanism would just fail
+// forever on the second attempt without ever reaching Resend again.
+func (q *Queries) UpsertEmailRequest(ctx context.Context, arg UpsertEmailRequestParams) (EmailRequest, error) {
+	row := q.db.QueryRow(ctx, upsertEmailRequest,
+		arg.ServiceID,
+		arg.QueueMessageID,
+		arg.Exchange,
+		arg.RoutingKey,
+		arg.FromAddress,
+		arg.ReplyTo,
+		arg.ToAddresses,
+		arg.CcAddresses,
+		arg.BccAddresses,
+		arg.Subject,
+		arg.BodyHtml,
+		arg.BodyText,
+		arg.Attachments,
+		arg.TemplateID,
+		arg.TemplateVars,
+		arg.Status,
+		arg.ProcessedAt,
+	)
 	var i EmailRequest
 	err := row.Scan(
 		&i.ID,

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -118,6 +118,7 @@ type Notification struct {
 	UpdatedAt               pgtype.Timestamp `json:"updated_at"`
 	SentAt                  pgtype.Timestamp `json:"sent_at"`
 	DeliveredAt             pgtype.Timestamp `json:"delivered_at"`
+	QueueMessageID          *string          `json:"queue_message_id"`
 }
 
 type Service struct {

--- a/internal/repository/notifications.sql.go
+++ b/internal/repository/notifications.sql.go
@@ -24,249 +24,6 @@ func (q *Queries) CleanupOldNotifications(ctx context.Context) error {
 	return err
 }
 
-const createNotification = `-- name: CreateNotification :one
-INSERT INTO notifications (
-    app_id,
-    included_segments,
-    excluded_segments,
-    include_player_ids,
-    include_external_user_ids,
-    include_email_tokens,
-    include_phone_numbers,
-    include_ios_tokens,
-    include_wp_wns_uris,
-    include_amazon_reg_ids,
-    include_chrome_reg_ids,
-    include_chrome_web_reg_ids,
-    include_android_reg_ids,
-    contents,
-    headings,
-    subtitle,
-    big_picture,
-    large_icon,
-    small_icon,
-    ios_attachments,
-    android_channel_id,
-    android_accent_color,
-    android_led_color,
-    android_group,
-    android_group_message,
-    android_sound,
-    ios_sound,
-    wp_wns_sound,
-    adm_sound,
-    chrome_web_image,
-    chrome_web_icon,
-    chrome_web_badge,
-    chrome_web_color,
-    chrome_web_sound,
-    url,
-    web_url,
-    app_url,
-    data,
-    filters,
-    tags,
-    send_after,
-    delayed_option,
-    delivery_time_of_day,
-    ttl,
-    priority,
-    target_user_id,
-    source_service_id,
-    source_user_id,
-    notification_type,
-    onesignal_notification_id,
-    onesignal_status,
-    onesignal_response,
-    onesignal_error
- 
-) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-    $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39,
-    $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53 
-)
-RETURNING id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at
-`
-
-type CreateNotificationParams struct {
-	AppID                   string           `json:"app_id"`
-	IncludedSegments        []string         `json:"included_segments"`
-	ExcludedSegments        []string         `json:"excluded_segments"`
-	IncludePlayerIds        []string         `json:"include_player_ids"`
-	IncludeExternalUserIds  []string         `json:"include_external_user_ids"`
-	IncludeEmailTokens      []string         `json:"include_email_tokens"`
-	IncludePhoneNumbers     []string         `json:"include_phone_numbers"`
-	IncludeIosTokens        []string         `json:"include_ios_tokens"`
-	IncludeWpWnsUris        []string         `json:"include_wp_wns_uris"`
-	IncludeAmazonRegIds     []string         `json:"include_amazon_reg_ids"`
-	IncludeChromeRegIds     []string         `json:"include_chrome_reg_ids"`
-	IncludeChromeWebRegIds  []string         `json:"include_chrome_web_reg_ids"`
-	IncludeAndroidRegIds    []string         `json:"include_android_reg_ids"`
-	Contents                json.RawMessage  `json:"contents"`
-	Headings                json.RawMessage  `json:"headings"`
-	Subtitle                json.RawMessage  `json:"subtitle"`
-	BigPicture              *string          `json:"big_picture"`
-	LargeIcon               *string          `json:"large_icon"`
-	SmallIcon               *string          `json:"small_icon"`
-	IosAttachments          json.RawMessage  `json:"ios_attachments"`
-	AndroidChannelID        *string          `json:"android_channel_id"`
-	AndroidAccentColor      *string          `json:"android_accent_color"`
-	AndroidLedColor         *string          `json:"android_led_color"`
-	AndroidGroup            *string          `json:"android_group"`
-	AndroidGroupMessage     json.RawMessage  `json:"android_group_message"`
-	AndroidSound            *string          `json:"android_sound"`
-	IosSound                *string          `json:"ios_sound"`
-	WpWnsSound              *string          `json:"wp_wns_sound"`
-	AdmSound                *string          `json:"adm_sound"`
-	ChromeWebImage          *string          `json:"chrome_web_image"`
-	ChromeWebIcon           *string          `json:"chrome_web_icon"`
-	ChromeWebBadge          *string          `json:"chrome_web_badge"`
-	ChromeWebColor          *string          `json:"chrome_web_color"`
-	ChromeWebSound          *string          `json:"chrome_web_sound"`
-	Url                     *string          `json:"url"`
-	WebUrl                  *string          `json:"web_url"`
-	AppUrl                  *string          `json:"app_url"`
-	Data                    json.RawMessage  `json:"data"`
-	Filters                 json.RawMessage  `json:"filters"`
-	Tags                    json.RawMessage  `json:"tags"`
-	SendAfter               pgtype.Timestamp `json:"send_after"`
-	DelayedOption           *string          `json:"delayed_option"`
-	DeliveryTimeOfDay       pgtype.Time      `json:"delivery_time_of_day"`
-	Ttl                     *int32           `json:"ttl"`
-	Priority                *int32           `json:"priority"`
-	TargetUserID            pgtype.UUID      `json:"target_user_id"`
-	SourceServiceID         *string          `json:"source_service_id"`
-	SourceUserID            pgtype.UUID      `json:"source_user_id"`
-	NotificationType        *string          `json:"notification_type"`
-	OnesignalNotificationID *string          `json:"onesignal_notification_id"`
-	OnesignalStatus         *string          `json:"onesignal_status"`
-	OnesignalResponse       json.RawMessage  `json:"onesignal_response"`
-	OnesignalError          *string          `json:"onesignal_error"`
-}
-
-func (q *Queries) CreateNotification(ctx context.Context, arg CreateNotificationParams) (Notification, error) {
-	row := q.db.QueryRow(ctx, createNotification,
-		arg.AppID,
-		arg.IncludedSegments,
-		arg.ExcludedSegments,
-		arg.IncludePlayerIds,
-		arg.IncludeExternalUserIds,
-		arg.IncludeEmailTokens,
-		arg.IncludePhoneNumbers,
-		arg.IncludeIosTokens,
-		arg.IncludeWpWnsUris,
-		arg.IncludeAmazonRegIds,
-		arg.IncludeChromeRegIds,
-		arg.IncludeChromeWebRegIds,
-		arg.IncludeAndroidRegIds,
-		arg.Contents,
-		arg.Headings,
-		arg.Subtitle,
-		arg.BigPicture,
-		arg.LargeIcon,
-		arg.SmallIcon,
-		arg.IosAttachments,
-		arg.AndroidChannelID,
-		arg.AndroidAccentColor,
-		arg.AndroidLedColor,
-		arg.AndroidGroup,
-		arg.AndroidGroupMessage,
-		arg.AndroidSound,
-		arg.IosSound,
-		arg.WpWnsSound,
-		arg.AdmSound,
-		arg.ChromeWebImage,
-		arg.ChromeWebIcon,
-		arg.ChromeWebBadge,
-		arg.ChromeWebColor,
-		arg.ChromeWebSound,
-		arg.Url,
-		arg.WebUrl,
-		arg.AppUrl,
-		arg.Data,
-		arg.Filters,
-		arg.Tags,
-		arg.SendAfter,
-		arg.DelayedOption,
-		arg.DeliveryTimeOfDay,
-		arg.Ttl,
-		arg.Priority,
-		arg.TargetUserID,
-		arg.SourceServiceID,
-		arg.SourceUserID,
-		arg.NotificationType,
-		arg.OnesignalNotificationID,
-		arg.OnesignalStatus,
-		arg.OnesignalResponse,
-		arg.OnesignalError,
-	)
-	var i Notification
-	err := row.Scan(
-		&i.ID,
-		&i.AppID,
-		&i.IncludedSegments,
-		&i.ExcludedSegments,
-		&i.IncludePlayerIds,
-		&i.IncludeExternalUserIds,
-		&i.IncludeEmailTokens,
-		&i.IncludePhoneNumbers,
-		&i.IncludeIosTokens,
-		&i.IncludeWpWnsUris,
-		&i.IncludeAmazonRegIds,
-		&i.IncludeChromeRegIds,
-		&i.IncludeChromeWebRegIds,
-		&i.IncludeAndroidRegIds,
-		&i.Contents,
-		&i.Headings,
-		&i.Subtitle,
-		&i.Buttons,
-		&i.WebButtons,
-		&i.BigPicture,
-		&i.LargeIcon,
-		&i.SmallIcon,
-		&i.IosAttachments,
-		&i.AndroidChannelID,
-		&i.AndroidAccentColor,
-		&i.AndroidLedColor,
-		&i.AndroidGroup,
-		&i.AndroidGroupMessage,
-		&i.AndroidSound,
-		&i.IosSound,
-		&i.WpWnsSound,
-		&i.AdmSound,
-		&i.ChromeWebImage,
-		&i.ChromeWebIcon,
-		&i.ChromeWebBadge,
-		&i.ChromeWebColor,
-		&i.ChromeWebSound,
-		&i.Url,
-		&i.WebUrl,
-		&i.AppUrl,
-		&i.Data,
-		&i.Filters,
-		&i.Tags,
-		&i.SendAfter,
-		&i.DelayedOption,
-		&i.DeliveryTimeOfDay,
-		&i.Ttl,
-		&i.Priority,
-		&i.OnesignalNotificationID,
-		&i.OnesignalStatus,
-		&i.OnesignalResponse,
-		&i.OnesignalError,
-		&i.TargetUserID,
-		&i.SourceServiceID,
-		&i.SourceUserID,
-		&i.NotificationType,
-		&i.Status,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.SentAt,
-		&i.DeliveredAt,
-	)
-	return i, err
-}
-
 const deleteNotification = `-- name: DeleteNotification :exec
 DELETE FROM notifications
 WHERE id = $1
@@ -278,7 +35,7 @@ func (q *Queries) DeleteNotification(ctx context.Context, id uuid.UUID) error {
 }
 
 const getNotificationByID = `-- name: GetNotificationByID :one
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE id = $1
 `
 
@@ -347,12 +104,13 @@ func (q *Queries) GetNotificationByID(ctx context.Context, id uuid.UUID) (Notifi
 		&i.UpdatedAt,
 		&i.SentAt,
 		&i.DeliveredAt,
+		&i.QueueMessageID,
 	)
 	return i, err
 }
 
 const getNotificationByOneSignalID = `-- name: GetNotificationByOneSignalID :one
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE onesignal_notification_id = $1
 `
 
@@ -421,6 +179,87 @@ func (q *Queries) GetNotificationByOneSignalID(ctx context.Context, onesignalNot
 		&i.UpdatedAt,
 		&i.SentAt,
 		&i.DeliveredAt,
+		&i.QueueMessageID,
+	)
+	return i, err
+}
+
+const getNotificationByQueueMessageID = `-- name: GetNotificationByQueueMessageID :one
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications
+WHERE queue_message_id = $1
+`
+
+// Used to detect a duplicate send before calling OneSignal: if a
+// notification with this queue_message_id was already sent, the caller
+// must skip resending rather than upsert-and-retry, or a legitimate DLX
+// redelivery and an external duplicate republish become indistinguishable
+// and both would trigger a second real send.
+func (q *Queries) GetNotificationByQueueMessageID(ctx context.Context, queueMessageID *string) (Notification, error) {
+	row := q.db.QueryRow(ctx, getNotificationByQueueMessageID, queueMessageID)
+	var i Notification
+	err := row.Scan(
+		&i.ID,
+		&i.AppID,
+		&i.IncludedSegments,
+		&i.ExcludedSegments,
+		&i.IncludePlayerIds,
+		&i.IncludeExternalUserIds,
+		&i.IncludeEmailTokens,
+		&i.IncludePhoneNumbers,
+		&i.IncludeIosTokens,
+		&i.IncludeWpWnsUris,
+		&i.IncludeAmazonRegIds,
+		&i.IncludeChromeRegIds,
+		&i.IncludeChromeWebRegIds,
+		&i.IncludeAndroidRegIds,
+		&i.Contents,
+		&i.Headings,
+		&i.Subtitle,
+		&i.Buttons,
+		&i.WebButtons,
+		&i.BigPicture,
+		&i.LargeIcon,
+		&i.SmallIcon,
+		&i.IosAttachments,
+		&i.AndroidChannelID,
+		&i.AndroidAccentColor,
+		&i.AndroidLedColor,
+		&i.AndroidGroup,
+		&i.AndroidGroupMessage,
+		&i.AndroidSound,
+		&i.IosSound,
+		&i.WpWnsSound,
+		&i.AdmSound,
+		&i.ChromeWebImage,
+		&i.ChromeWebIcon,
+		&i.ChromeWebBadge,
+		&i.ChromeWebColor,
+		&i.ChromeWebSound,
+		&i.Url,
+		&i.WebUrl,
+		&i.AppUrl,
+		&i.Data,
+		&i.Filters,
+		&i.Tags,
+		&i.SendAfter,
+		&i.DelayedOption,
+		&i.DeliveryTimeOfDay,
+		&i.Ttl,
+		&i.Priority,
+		&i.OnesignalNotificationID,
+		&i.OnesignalStatus,
+		&i.OnesignalResponse,
+		&i.OnesignalError,
+		&i.TargetUserID,
+		&i.SourceServiceID,
+		&i.SourceUserID,
+		&i.NotificationType,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.SentAt,
+		&i.DeliveredAt,
+		&i.QueueMessageID,
 	)
 	return i, err
 }
@@ -496,7 +335,7 @@ func (q *Queries) GetNotificationStatsByType(ctx context.Context, notificationTy
 }
 
 const getNotificationsByExternalUserID = `-- name: GetNotificationsByExternalUserID :many
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE $1 = ANY(include_external_user_ids)
 ORDER BY created_at DESC
 LIMIT $2
@@ -580,6 +419,7 @@ func (q *Queries) GetNotificationsByExternalUserID(ctx context.Context, arg GetN
 			&i.UpdatedAt,
 			&i.SentAt,
 			&i.DeliveredAt,
+			&i.QueueMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -592,7 +432,7 @@ func (q *Queries) GetNotificationsByExternalUserID(ctx context.Context, arg GetN
 }
 
 const getNotificationsByStatus = `-- name: GetNotificationsByStatus :many
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE status = $1
 ORDER BY created_at DESC
 LIMIT $2
@@ -676,6 +516,7 @@ func (q *Queries) GetNotificationsByStatus(ctx context.Context, arg GetNotificat
 			&i.UpdatedAt,
 			&i.SentAt,
 			&i.DeliveredAt,
+			&i.QueueMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -688,7 +529,7 @@ func (q *Queries) GetNotificationsByStatus(ctx context.Context, arg GetNotificat
 }
 
 const getNotificationsByTargetUser = `-- name: GetNotificationsByTargetUser :many
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE target_user_id = $1
 ORDER BY created_at DESC
 LIMIT $2
@@ -772,6 +613,7 @@ func (q *Queries) GetNotificationsByTargetUser(ctx context.Context, arg GetNotif
 			&i.UpdatedAt,
 			&i.SentAt,
 			&i.DeliveredAt,
+			&i.QueueMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -784,7 +626,7 @@ func (q *Queries) GetNotificationsByTargetUser(ctx context.Context, arg GetNotif
 }
 
 const getNotificationsByType = `-- name: GetNotificationsByType :many
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE notification_type = $1
 ORDER BY created_at DESC
 LIMIT $2
@@ -868,6 +710,7 @@ func (q *Queries) GetNotificationsByType(ctx context.Context, arg GetNotificatio
 			&i.UpdatedAt,
 			&i.SentAt,
 			&i.DeliveredAt,
+			&i.QueueMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -880,7 +723,7 @@ func (q *Queries) GetNotificationsByType(ctx context.Context, arg GetNotificatio
 }
 
 const getPendingNotifications = `-- name: GetPendingNotifications :many
-SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at FROM notifications 
+SELECT id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id FROM notifications 
 WHERE status = 'pending'
   AND (send_after IS NULL OR send_after <= NOW())
 ORDER BY created_at ASC
@@ -958,6 +801,7 @@ func (q *Queries) GetPendingNotifications(ctx context.Context, limit int32) ([]N
 			&i.UpdatedAt,
 			&i.SentAt,
 			&i.DeliveredAt,
+			&i.QueueMessageID,
 		); err != nil {
 			return nil, err
 		}
@@ -1043,4 +887,315 @@ func (q *Queries) UpdateNotificationStatus(ctx context.Context, arg UpdateNotifi
 		arg.OnesignalError,
 	)
 	return err
+}
+
+const upsertNotification = `-- name: UpsertNotification :one
+INSERT INTO notifications (
+    app_id,
+    included_segments,
+    excluded_segments,
+    include_player_ids,
+    include_external_user_ids,
+    include_email_tokens,
+    include_phone_numbers,
+    include_ios_tokens,
+    include_wp_wns_uris,
+    include_amazon_reg_ids,
+    include_chrome_reg_ids,
+    include_chrome_web_reg_ids,
+    include_android_reg_ids,
+    contents,
+    headings,
+    subtitle,
+    big_picture,
+    large_icon,
+    small_icon,
+    ios_attachments,
+    android_channel_id,
+    android_accent_color,
+    android_led_color,
+    android_group,
+    android_group_message,
+    android_sound,
+    ios_sound,
+    wp_wns_sound,
+    adm_sound,
+    chrome_web_image,
+    chrome_web_icon,
+    chrome_web_badge,
+    chrome_web_color,
+    chrome_web_sound,
+    url,
+    web_url,
+    app_url,
+    data,
+    filters,
+    tags,
+    send_after,
+    delayed_option,
+    delivery_time_of_day,
+    ttl,
+    priority,
+    target_user_id,
+    source_service_id,
+    source_user_id,
+    notification_type,
+    onesignal_notification_id,
+    onesignal_status,
+    onesignal_response,
+    onesignal_error,
+    queue_message_id,
+    status
+
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
+    $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39,
+    $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51, $52, $53, $54, $55
+)
+ON CONFLICT (queue_message_id) DO UPDATE SET
+    app_id = EXCLUDED.app_id,
+    included_segments = EXCLUDED.included_segments,
+    excluded_segments = EXCLUDED.excluded_segments,
+    include_player_ids = EXCLUDED.include_player_ids,
+    include_external_user_ids = EXCLUDED.include_external_user_ids,
+    include_email_tokens = EXCLUDED.include_email_tokens,
+    include_phone_numbers = EXCLUDED.include_phone_numbers,
+    include_ios_tokens = EXCLUDED.include_ios_tokens,
+    include_wp_wns_uris = EXCLUDED.include_wp_wns_uris,
+    include_amazon_reg_ids = EXCLUDED.include_amazon_reg_ids,
+    include_chrome_reg_ids = EXCLUDED.include_chrome_reg_ids,
+    include_chrome_web_reg_ids = EXCLUDED.include_chrome_web_reg_ids,
+    include_android_reg_ids = EXCLUDED.include_android_reg_ids,
+    contents = EXCLUDED.contents,
+    headings = EXCLUDED.headings,
+    subtitle = EXCLUDED.subtitle,
+    big_picture = EXCLUDED.big_picture,
+    large_icon = EXCLUDED.large_icon,
+    small_icon = EXCLUDED.small_icon,
+    ios_attachments = EXCLUDED.ios_attachments,
+    android_channel_id = EXCLUDED.android_channel_id,
+    android_accent_color = EXCLUDED.android_accent_color,
+    android_led_color = EXCLUDED.android_led_color,
+    android_group = EXCLUDED.android_group,
+    android_group_message = EXCLUDED.android_group_message,
+    android_sound = EXCLUDED.android_sound,
+    ios_sound = EXCLUDED.ios_sound,
+    wp_wns_sound = EXCLUDED.wp_wns_sound,
+    adm_sound = EXCLUDED.adm_sound,
+    chrome_web_image = EXCLUDED.chrome_web_image,
+    chrome_web_icon = EXCLUDED.chrome_web_icon,
+    chrome_web_badge = EXCLUDED.chrome_web_badge,
+    chrome_web_color = EXCLUDED.chrome_web_color,
+    chrome_web_sound = EXCLUDED.chrome_web_sound,
+    url = EXCLUDED.url,
+    web_url = EXCLUDED.web_url,
+    app_url = EXCLUDED.app_url,
+    data = EXCLUDED.data,
+    filters = EXCLUDED.filters,
+    tags = EXCLUDED.tags,
+    send_after = EXCLUDED.send_after,
+    delayed_option = EXCLUDED.delayed_option,
+    delivery_time_of_day = EXCLUDED.delivery_time_of_day,
+    ttl = EXCLUDED.ttl,
+    priority = EXCLUDED.priority,
+    target_user_id = EXCLUDED.target_user_id,
+    source_service_id = EXCLUDED.source_service_id,
+    source_user_id = EXCLUDED.source_user_id,
+    notification_type = EXCLUDED.notification_type,
+    onesignal_notification_id = EXCLUDED.onesignal_notification_id,
+    onesignal_status = EXCLUDED.onesignal_status,
+    onesignal_response = EXCLUDED.onesignal_response,
+    onesignal_error = EXCLUDED.onesignal_error,
+    status = EXCLUDED.status,
+    updated_at = NOW()
+RETURNING id, app_id, included_segments, excluded_segments, include_player_ids, include_external_user_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, contents, headings, subtitle, buttons, web_buttons, big_picture, large_icon, small_icon, ios_attachments, android_channel_id, android_accent_color, android_led_color, android_group, android_group_message, android_sound, ios_sound, wp_wns_sound, adm_sound, chrome_web_image, chrome_web_icon, chrome_web_badge, chrome_web_color, chrome_web_sound, url, web_url, app_url, data, filters, tags, send_after, delayed_option, delivery_time_of_day, ttl, priority, onesignal_notification_id, onesignal_status, onesignal_response, onesignal_error, target_user_id, source_service_id, source_user_id, notification_type, status, created_at, updated_at, sent_at, delivered_at, queue_message_id
+`
+
+type UpsertNotificationParams struct {
+	AppID                   string           `json:"app_id"`
+	IncludedSegments        []string         `json:"included_segments"`
+	ExcludedSegments        []string         `json:"excluded_segments"`
+	IncludePlayerIds        []string         `json:"include_player_ids"`
+	IncludeExternalUserIds  []string         `json:"include_external_user_ids"`
+	IncludeEmailTokens      []string         `json:"include_email_tokens"`
+	IncludePhoneNumbers     []string         `json:"include_phone_numbers"`
+	IncludeIosTokens        []string         `json:"include_ios_tokens"`
+	IncludeWpWnsUris        []string         `json:"include_wp_wns_uris"`
+	IncludeAmazonRegIds     []string         `json:"include_amazon_reg_ids"`
+	IncludeChromeRegIds     []string         `json:"include_chrome_reg_ids"`
+	IncludeChromeWebRegIds  []string         `json:"include_chrome_web_reg_ids"`
+	IncludeAndroidRegIds    []string         `json:"include_android_reg_ids"`
+	Contents                json.RawMessage  `json:"contents"`
+	Headings                json.RawMessage  `json:"headings"`
+	Subtitle                json.RawMessage  `json:"subtitle"`
+	BigPicture              *string          `json:"big_picture"`
+	LargeIcon               *string          `json:"large_icon"`
+	SmallIcon               *string          `json:"small_icon"`
+	IosAttachments          json.RawMessage  `json:"ios_attachments"`
+	AndroidChannelID        *string          `json:"android_channel_id"`
+	AndroidAccentColor      *string          `json:"android_accent_color"`
+	AndroidLedColor         *string          `json:"android_led_color"`
+	AndroidGroup            *string          `json:"android_group"`
+	AndroidGroupMessage     json.RawMessage  `json:"android_group_message"`
+	AndroidSound            *string          `json:"android_sound"`
+	IosSound                *string          `json:"ios_sound"`
+	WpWnsSound              *string          `json:"wp_wns_sound"`
+	AdmSound                *string          `json:"adm_sound"`
+	ChromeWebImage          *string          `json:"chrome_web_image"`
+	ChromeWebIcon           *string          `json:"chrome_web_icon"`
+	ChromeWebBadge          *string          `json:"chrome_web_badge"`
+	ChromeWebColor          *string          `json:"chrome_web_color"`
+	ChromeWebSound          *string          `json:"chrome_web_sound"`
+	Url                     *string          `json:"url"`
+	WebUrl                  *string          `json:"web_url"`
+	AppUrl                  *string          `json:"app_url"`
+	Data                    json.RawMessage  `json:"data"`
+	Filters                 json.RawMessage  `json:"filters"`
+	Tags                    json.RawMessage  `json:"tags"`
+	SendAfter               pgtype.Timestamp `json:"send_after"`
+	DelayedOption           *string          `json:"delayed_option"`
+	DeliveryTimeOfDay       pgtype.Time      `json:"delivery_time_of_day"`
+	Ttl                     *int32           `json:"ttl"`
+	Priority                *int32           `json:"priority"`
+	TargetUserID            pgtype.UUID      `json:"target_user_id"`
+	SourceServiceID         *string          `json:"source_service_id"`
+	SourceUserID            pgtype.UUID      `json:"source_user_id"`
+	NotificationType        *string          `json:"notification_type"`
+	OnesignalNotificationID *string          `json:"onesignal_notification_id"`
+	OnesignalStatus         *string          `json:"onesignal_status"`
+	OnesignalResponse       json.RawMessage  `json:"onesignal_response"`
+	OnesignalError          *string          `json:"onesignal_error"`
+	QueueMessageID          *string          `json:"queue_message_id"`
+	Status                  *string          `json:"status"`
+}
+
+// Inserts a notification send attempt, or updates it in place if this is a
+// retry of the same queue_message_id (dead-lettered redelivery). Keeping one
+// row per logical send, updated across attempts, matches how this table
+// already behaves (a single mutable outcome row, not an attempt-history
+// table like email_requests/email_dispatches).
+func (q *Queries) UpsertNotification(ctx context.Context, arg UpsertNotificationParams) (Notification, error) {
+	row := q.db.QueryRow(ctx, upsertNotification,
+		arg.AppID,
+		arg.IncludedSegments,
+		arg.ExcludedSegments,
+		arg.IncludePlayerIds,
+		arg.IncludeExternalUserIds,
+		arg.IncludeEmailTokens,
+		arg.IncludePhoneNumbers,
+		arg.IncludeIosTokens,
+		arg.IncludeWpWnsUris,
+		arg.IncludeAmazonRegIds,
+		arg.IncludeChromeRegIds,
+		arg.IncludeChromeWebRegIds,
+		arg.IncludeAndroidRegIds,
+		arg.Contents,
+		arg.Headings,
+		arg.Subtitle,
+		arg.BigPicture,
+		arg.LargeIcon,
+		arg.SmallIcon,
+		arg.IosAttachments,
+		arg.AndroidChannelID,
+		arg.AndroidAccentColor,
+		arg.AndroidLedColor,
+		arg.AndroidGroup,
+		arg.AndroidGroupMessage,
+		arg.AndroidSound,
+		arg.IosSound,
+		arg.WpWnsSound,
+		arg.AdmSound,
+		arg.ChromeWebImage,
+		arg.ChromeWebIcon,
+		arg.ChromeWebBadge,
+		arg.ChromeWebColor,
+		arg.ChromeWebSound,
+		arg.Url,
+		arg.WebUrl,
+		arg.AppUrl,
+		arg.Data,
+		arg.Filters,
+		arg.Tags,
+		arg.SendAfter,
+		arg.DelayedOption,
+		arg.DeliveryTimeOfDay,
+		arg.Ttl,
+		arg.Priority,
+		arg.TargetUserID,
+		arg.SourceServiceID,
+		arg.SourceUserID,
+		arg.NotificationType,
+		arg.OnesignalNotificationID,
+		arg.OnesignalStatus,
+		arg.OnesignalResponse,
+		arg.OnesignalError,
+		arg.QueueMessageID,
+		arg.Status,
+	)
+	var i Notification
+	err := row.Scan(
+		&i.ID,
+		&i.AppID,
+		&i.IncludedSegments,
+		&i.ExcludedSegments,
+		&i.IncludePlayerIds,
+		&i.IncludeExternalUserIds,
+		&i.IncludeEmailTokens,
+		&i.IncludePhoneNumbers,
+		&i.IncludeIosTokens,
+		&i.IncludeWpWnsUris,
+		&i.IncludeAmazonRegIds,
+		&i.IncludeChromeRegIds,
+		&i.IncludeChromeWebRegIds,
+		&i.IncludeAndroidRegIds,
+		&i.Contents,
+		&i.Headings,
+		&i.Subtitle,
+		&i.Buttons,
+		&i.WebButtons,
+		&i.BigPicture,
+		&i.LargeIcon,
+		&i.SmallIcon,
+		&i.IosAttachments,
+		&i.AndroidChannelID,
+		&i.AndroidAccentColor,
+		&i.AndroidLedColor,
+		&i.AndroidGroup,
+		&i.AndroidGroupMessage,
+		&i.AndroidSound,
+		&i.IosSound,
+		&i.WpWnsSound,
+		&i.AdmSound,
+		&i.ChromeWebImage,
+		&i.ChromeWebIcon,
+		&i.ChromeWebBadge,
+		&i.ChromeWebColor,
+		&i.ChromeWebSound,
+		&i.Url,
+		&i.WebUrl,
+		&i.AppUrl,
+		&i.Data,
+		&i.Filters,
+		&i.Tags,
+		&i.SendAfter,
+		&i.DelayedOption,
+		&i.DeliveryTimeOfDay,
+		&i.Ttl,
+		&i.Priority,
+		&i.OnesignalNotificationID,
+		&i.OnesignalStatus,
+		&i.OnesignalResponse,
+		&i.OnesignalError,
+		&i.TargetUserID,
+		&i.SourceServiceID,
+		&i.SourceUserID,
+		&i.NotificationType,
+		&i.Status,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.SentAt,
+		&i.DeliveredAt,
+		&i.QueueMessageID,
+	)
+	return i, err
 }

--- a/internal/repository/querier.go
+++ b/internal/repository/querier.go
@@ -16,17 +16,26 @@ type Querier interface {
 	// Records an email dispatch to the email sending service for compliance
 	// purposes
 	CreateEmailDispatch(ctx context.Context, arg CreateEmailDispatchParams) (EmailDispatch, error)
-	// Persists an email request to the database for replayability
-	CreateEmailRequest(ctx context.Context, arg CreateEmailRequestParams) (EmailRequest, error)
-	CreateNotification(ctx context.Context, arg CreateNotificationParams) (Notification, error)
 	CreateUser(ctx context.Context, arg CreateUserParams) (User, error)
 	DeleteNotification(ctx context.Context, id uuid.UUID) error
 	DeleteUserByID(ctx context.Context, id uuid.UUID) error
 	GetEmailRequestByID(ctx context.Context, id uuid.UUID) (EmailRequest, error)
+	// Used to detect a duplicate send before calling Resend: if a request with
+	// this queue_message_id was already dispatched, the caller must skip
+	// resending rather than upsert-and-retry, or a legitimate DLX redelivery
+	// and an external duplicate republish become indistinguishable and both
+	// would trigger a second real send.
+	GetEmailRequestByQueueMessageID(ctx context.Context, queueMessageID string) (EmailRequest, error)
 	// Orders the time it was recieved ie the most previous
 	GetEmailRequestByService(ctx context.Context, arg GetEmailRequestByServiceParams) ([]EmailRequest, error)
 	GetNotificationByID(ctx context.Context, id uuid.UUID) (Notification, error)
 	GetNotificationByOneSignalID(ctx context.Context, onesignalNotificationID *string) (Notification, error)
+	// Used to detect a duplicate send before calling OneSignal: if a
+	// notification with this queue_message_id was already sent, the caller
+	// must skip resending rather than upsert-and-retry, or a legitimate DLX
+	// redelivery and an external duplicate republish become indistinguishable
+	// and both would trigger a second real send.
+	GetNotificationByQueueMessageID(ctx context.Context, queueMessageID *string) (Notification, error)
 	GetNotificationStats(ctx context.Context, targetUserID pgtype.UUID) (GetNotificationStatsRow, error)
 	GetNotificationStatsByType(ctx context.Context, notificationType *string) (GetNotificationStatsByTypeRow, error)
 	GetNotificationsByExternalUserID(ctx context.Context, arg GetNotificationsByExternalUserIDParams) ([]Notification, error)
@@ -44,6 +53,18 @@ type Querier interface {
 	UpdateNotificationOneSignalData(ctx context.Context, arg UpdateNotificationOneSignalDataParams) error
 	UpdateNotificationStatus(ctx context.Context, arg UpdateNotificationStatusParams) error
 	UpdateUserByID(ctx context.Context, arg UpdateUserByIDParams) (User, error)
+	// Persists an email request to the database for replayability, or updates
+	// it in place if this is a retry of the same queue_message_id (dead-lettered
+	// redelivery) — retrying must not hit the queue_message_id UNIQUE
+	// constraint as a fresh insert, or the retry mechanism would just fail
+	// forever on the second attempt without ever reaching Resend again.
+	UpsertEmailRequest(ctx context.Context, arg UpsertEmailRequestParams) (EmailRequest, error)
+	// Inserts a notification send attempt, or updates it in place if this is a
+	// retry of the same queue_message_id (dead-lettered redelivery). Keeping one
+	// row per logical send, updated across attempts, matches how this table
+	// already behaves (a single mutable outcome row, not an attempt-history
+	// table like email_requests/email_dispatches).
+	UpsertNotification(ctx context.Context, arg UpsertNotificationParams) (Notification, error)
 	// Registers a service on first use so email onboarding is self-service;
 	// ON CONFLICT DO UPDATE (a no-op) instead of DO NOTHING so RETURNING always
 	// yields exactly one row, whether the service already existed or not.

--- a/internal/resilience/breaker.go
+++ b/internal/resilience/breaker.go
@@ -1,0 +1,64 @@
+package resilience
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+)
+
+// Breaker is the minimal surface this package depends on, satisfied by
+// *gobreaker.CircuitBreaker[T]. Defined as an interface so callers can
+// inject a fake in tests to force the open-state path.
+type Breaker[T any] interface {
+	Execute(req func() (T, error)) (T, error)
+}
+
+// Settings configures a Breaker's failure threshold and recovery timing.
+type Settings struct {
+	// ConsecutiveFailures is how many consecutive failures while closed
+	// trip the breaker open.
+	ConsecutiveFailures uint32
+	// OpenTimeout is how long the breaker stays open before allowing a
+	// half-open trial request through.
+	OpenTimeout time.Duration
+	// HalfOpenMaxRequests is how many trial requests are allowed through
+	// while half-open before deciding to close or re-open.
+	HalfOpenMaxRequests uint32
+}
+
+// New builds a named circuit breaker. State transitions are logged through
+// logger: opening at Warn (something is actually down), closing/half-open
+// trials at Info.
+func New[T any](name string, settings Settings, logger *slog.Logger) Breaker[T] {
+	return gobreaker.NewCircuitBreaker[T](gobreaker.Settings{
+		Name:        name,
+		MaxRequests: settings.HalfOpenMaxRequests,
+		Timeout:     settings.OpenTimeout,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= settings.ConsecutiveFailures
+		},
+		OnStateChange: func(name string, from, to gobreaker.State) {
+			level := slog.LevelInfo
+			if to == gobreaker.StateOpen {
+				level = slog.LevelWarn
+			}
+			logger.Log(context.Background(), level,
+				"circuit breaker state change",
+				slog.String("breaker", name),
+				slog.String("from", from.String()),
+				slog.String("to", to.String()),
+			)
+		},
+	})
+}
+
+// Open reports whether err indicates the breaker rejected the call outright
+// (open, or half-open with its trial quota exhausted) rather than the
+// underlying call itself having failed.
+func Open(err error) bool {
+	return errors.Is(err, gobreaker.ErrOpenState) ||
+		errors.Is(err, gobreaker.ErrTooManyRequests)
+}

--- a/internal/resilience/breaker_test.go
+++ b/internal/resilience/breaker_test.go
@@ -1,0 +1,63 @@
+package resilience
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestNew_TripsOpenAfterConsecutiveFailures(t *testing.T) {
+	b := New[string]("test", Settings{
+		ConsecutiveFailures: 3,
+		OpenTimeout:         time.Minute,
+		HalfOpenMaxRequests: 1,
+	}, discardLogger())
+
+	failing := func() (string, error) { return "", errors.New("boom") }
+
+	for i := 0; i < 3; i++ {
+		_, err := b.Execute(failing)
+		require.Error(t, err)
+		assert.False(t, Open(err), "underlying call failures should not be reported as breaker-open")
+	}
+
+	// The 3rd consecutive failure should have tripped the breaker open, so
+	// this call must be rejected without invoking failing again.
+	called := false
+	_, err := b.Execute(func() (string, error) {
+		called = true
+		return "", errors.New("should not run")
+	})
+
+	require.Error(t, err)
+	assert.False(t, called, "breaker should short-circuit and never invoke the wrapped call")
+	assert.True(t, Open(err), "rejection while open should be reported as breaker-open")
+	assert.True(t, errors.Is(err, gobreaker.ErrOpenState))
+}
+
+func TestOpen_FalseForOrdinaryErrors(t *testing.T) {
+	assert.False(t, Open(errors.New("some ordinary failure")))
+	assert.False(t, Open(nil))
+}
+
+func TestNew_SuccessfulCallsPassThrough(t *testing.T) {
+	b := New[int]("test", Settings{
+		ConsecutiveFailures: 5,
+		OpenTimeout:         time.Minute,
+		HalfOpenMaxRequests: 1,
+	}, discardLogger())
+
+	v, err := b.Execute(func() (int, error) { return 42, nil })
+	require.NoError(t, err)
+	assert.Equal(t, 42, v)
+}

--- a/internal/service/email_service.go
+++ b/internal/service/email_service.go
@@ -3,13 +3,16 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/opencrafts-io/gossip-monger/internal/repository"
+	"github.com/opencrafts-io/gossip-monger/internal/resilience"
 	"github.com/resend/resend-go/v3"
 )
 
@@ -22,18 +25,21 @@ type emailService struct {
 	logger               *slog.Logger
 	emailClient          *resend.Client
 	allowedSenderDomains []string
+	breaker              resilience.Breaker[*resend.SendEmailResponse]
 }
 
 func NewEmailService(
 	pool *pgxpool.Pool,
 	emailClient *resend.Client,
 	allowedSenderDomains []string,
+	breakerSettings resilience.Settings,
 	logger *slog.Logger,
 ) EmailService {
 	return &emailService{
 		pool:                 pool,
 		emailClient:          emailClient,
 		allowedSenderDomains: allowedSenderDomains,
+		breaker:              resilience.New[*resend.SendEmailResponse]("resend", breakerSettings, logger),
 		logger:               logger,
 	}
 }
@@ -64,6 +70,25 @@ func (es *emailService) Send(ctx context.Context, emailEvent EmailEvent) error {
 
 	repo := repository.New(tx)
 
+	// A retry (DLX redelivery) and an external duplicate republish of the
+	// same request_id are indistinguishable at this point — both must be
+	// safe. If this request_id already reached Resend successfully, skip
+	// resending: the upsert below would otherwise happily retry a send
+	// that already went through.
+	if existing, err := repo.GetEmailRequestByQueueMessageID(
+		ctx,
+		emailEvent.Meta.RequestID,
+	); err == nil {
+		if existing.Status == "dispatched" {
+			es.logger.Info("duplicate request_id already dispatched, skipping resend",
+				"request_id", emailEvent.Meta.RequestID,
+			)
+			return nil
+		}
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("failed to check for duplicate email request: %w", err)
+	}
+
 	if _, err := repo.UpsertService(ctx, repository.UpsertServiceParams{
 		ID:   emailEvent.Meta.SourceServiceID,
 		Name: emailEvent.Meta.SourceServiceID,
@@ -72,9 +97,9 @@ func (es *emailService) Send(ctx context.Context, emailEvent EmailEvent) error {
 	}
 
 	now := time.Now()
-	emailReq, err := repo.CreateEmailRequest(
+	emailReq, err := repo.UpsertEmailRequest(
 		ctx,
-		repository.CreateEmailRequestParams{
+		repository.UpsertEmailRequestParams{
 			ServiceID:      emailEvent.Meta.SourceServiceID,
 			QueueMessageID: emailEvent.Meta.RequestID,
 			Exchange:       "gossip.topic.exchange",
@@ -103,17 +128,24 @@ func (es *emailService) Send(ctx context.Context, emailEvent EmailEvent) error {
 		return fmt.Errorf("failed to convert email to resend request: %w", err)
 	}
 
-	sent, resendErr := es.emailClient.Emails.Send(resendRequest)
+	sent, resendErr := es.breaker.Execute(func() (*resend.SendEmailResponse, error) {
+		return es.emailClient.Emails.Send(resendRequest)
+	})
 
 	resendPayload, err := json.Marshal(resendRequest)
 	if err != nil {
 		return fmt.Errorf("failed to marshal resend payload: %w", err)
 	}
 
-	// Determine dispatch status based on Resend API response
+	// Determine dispatch status based on Resend API response. circuit_open
+	// is distinct from failed so operators can tell "the provider was
+	// already known-down, we didn't even try" apart from "we tried and
+	// Resend rejected this payload."
 	dispatchStatus := "failed"
 	if resendErr == nil {
 		dispatchStatus = "sent"
+	} else if resilience.Open(resendErr) {
+		dispatchStatus = "circuit_open"
 	}
 
 	dispatchParams := repository.CreateEmailDispatchParams{
@@ -129,6 +161,7 @@ func (es *emailService) Send(ctx context.Context, emailEvent EmailEvent) error {
 		dispatchParams.HttpStatusCode = &statusCode
 		es.logger.Error("resend delivery failed",
 			"email_request_id", emailReq.ID,
+			"status", dispatchStatus,
 			"error", resendErr,
 		)
 	} else {
@@ -148,7 +181,7 @@ func (es *emailService) Send(ctx context.Context, emailEvent EmailEvent) error {
 
 	finalStatus := "dispatched"
 	if resendErr != nil {
-		finalStatus = "failed"
+		finalStatus = dispatchStatus // "failed" or "circuit_open"
 	}
 	_, err = repo.UpdateEmailRequestStatusByID(
 		ctx,
@@ -161,11 +194,17 @@ func (es *emailService) Send(ctx context.Context, emailEvent EmailEvent) error {
 		return fmt.Errorf("failed to update email request status: %w", err)
 	}
 
-	// Commit the transaction
+	// Commit the transaction so the attempt is recorded regardless of
+	// outcome, then propagate resendErr so the consumer nacks the message
+	// for a retry instead of acking a failed send as if it succeeded.
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 	commited = true
+
+	if resendErr != nil {
+		return fmt.Errorf("failed to send email via resend: %w", resendErr)
+	}
 
 	return nil
 }

--- a/internal/service/push_notification_service.go
+++ b/internal/service/push_notification_service.go
@@ -12,8 +12,17 @@ import (
 	"time"
 
 	"github.com/OneSignal/onesignal-go-api/v5"
+	"github.com/jackc/pgx/v5"
 	"github.com/opencrafts-io/gossip-monger/internal/repository"
+	"github.com/opencrafts-io/gossip-monger/internal/resilience"
 )
+
+// onesignalCallResult bundles the two non-error return values of the
+// OneSignal CreateNotification call so it fits the breaker's single-value
+// generic signature.
+type onesignalCallResult struct {
+	httpResp *http.Response
+}
 
 type PushNotificationEventMetaData struct {
 	EventType       string    `json:"event_type"`
@@ -28,23 +37,26 @@ type PushNotificationEvent struct {
 }
 
 type PushNotificationService interface {
-	Send(context.Context, repository.Notification) error
+	Send(ctx context.Context, push repository.Notification, queueMessageID string) error
 }
 
 type pushNotificationService struct {
 	repo            repository.Querier
 	logger          *slog.Logger
 	onesignalClient *onesignal.APIClient
+	breaker         resilience.Breaker[*onesignalCallResult]
 }
 
 func NewPushNotificationService(
 	repo repository.Querier,
 	logger *slog.Logger,
 	onesignalClient *onesignal.APIClient,
+	breakerSettings resilience.Settings,
 ) PushNotificationService {
 	return &pushNotificationService{
 		repo:            repo,
 		onesignalClient: onesignalClient,
+		breaker:         resilience.New[*onesignalCallResult]("onesignal", breakerSettings, logger),
 		logger:          logger,
 	}
 }
@@ -52,49 +64,97 @@ func NewPushNotificationService(
 func (pns *pushNotificationService) Send(
 	ctx context.Context,
 	push repository.Notification,
+	queueMessageID string,
 ) error {
+	push.QueueMessageID = &queueMessageID
+
+	// A retry (DLX redelivery) and an external duplicate republish of the
+	// same queueMessageID are indistinguishable at this point — both must
+	// be safe. If this id already reached OneSignal successfully, skip
+	// resending: proceeding would happily resend a push that already went
+	// through.
+	existing, err := pns.repo.GetNotificationByQueueMessageID(ctx, &queueMessageID)
+	if err == nil {
+		if existing.Status != nil && *existing.Status == "sent" {
+			pns.logger.Info("duplicate queue_message_id already sent, skipping resend",
+				"queue_message_id", queueMessageID,
+			)
+			return nil
+		}
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("failed to check for duplicate notification: %w", err)
+	}
+
 	payload, err := pns.preparePushPayload(push)
 	if err != nil {
+		if persistErr := pns.persistOutcome(ctx, &push, "failed"); persistErr != nil {
+			pns.logger.Error("failed to persist notification after validation error",
+				"error", persistErr,
+			)
+		}
 		return err
 	}
 
-	_, code, err := pns.onesignalClient.DefaultApi.
-		CreateNotification(ctx).Notification(*payload).Execute()
+	result, callErr := pns.breaker.Execute(func() (*onesignalCallResult, error) {
+		_, httpResp, err := pns.onesignalClient.DefaultApi.
+			CreateNotification(ctx).Notification(*payload).Execute()
+		return &onesignalCallResult{httpResp: httpResp}, err
+	})
 
 	var body []byte
-	if code != nil && code.Body != nil {
-		defer code.Body.Close()
-		body, _ = io.ReadAll(code.Body)
+	statusCode := 0
+	if result != nil && result.httpResp != nil {
+		statusCode = result.httpResp.StatusCode
+		if result.httpResp.Body != nil {
+			defer result.httpResp.Body.Close()
+			body, _ = io.ReadAll(result.httpResp.Body)
+		}
 	}
 
-	// Parse response
-	notificationID, rawResponse, parseErr := pns.parseOnesignalResponse(
-		body,
-		code.StatusCode,
-	)
-
-	// Enrich notification with response data
-	if err != nil {
-		enrichNotificationFromResponse(&push, "", rawResponse, err)
-		return err
+	// Parse response (only meaningful if the call actually reached OneSignal)
+	var notificationID string
+	var rawResponse json.RawMessage
+	var parseErr error
+	if callErr == nil {
+		notificationID, rawResponse, parseErr = pns.parseOnesignalResponse(body, statusCode)
 	}
 
-	if parseErr != nil {
-		enrichNotificationFromResponse(&push, "", rawResponse, parseErr)
-		return parseErr
+	finalErr := callErr
+	if finalErr == nil {
+		finalErr = parseErr
+	}
+	enrichNotificationFromResponse(&push, notificationID, rawResponse, finalErr)
+
+	outcomeStatus := "sent"
+	switch {
+	case resilience.Open(callErr):
+		outcomeStatus = "circuit_open"
+	case finalErr != nil:
+		outcomeStatus = "failed"
 	}
 
-	// Success path
-	enrichNotificationFromResponse(&push, notificationID, rawResponse, nil)
+	if persistErr := pns.persistOutcome(ctx, &push, outcomeStatus); persistErr != nil {
+		return persistErr
+	}
 
-	_, err = pns.repo.CreateNotification(
+	return finalErr
+}
+
+// persistOutcome upserts push (keyed by its QueueMessageID) with the given
+// status, recording every attempt — success, provider error, or
+// breaker-rejected — rather than only ever recording success.
+func (pns *pushNotificationService) persistOutcome(
+	ctx context.Context,
+	push *repository.Notification,
+	status string,
+) error {
+	push.Status = &status
+	if _, err := pns.repo.UpsertNotification(
 		ctx,
-		pns.notificationToCreateParams(&push),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to persist notification %w", err)
+		pns.notificationToUpsertParams(push),
+	); err != nil {
+		return fmt.Errorf("failed to persist notification: %w", err)
 	}
-
 	return nil
 }
 
@@ -158,10 +218,10 @@ func enrichNotificationFromResponse(
 	}
 }
 
-func (pns *pushNotificationService) notificationToCreateParams(
+func (pns *pushNotificationService) notificationToUpsertParams(
 	n *repository.Notification,
-) repository.CreateNotificationParams {
-	return repository.CreateNotificationParams{
+) repository.UpsertNotificationParams {
+	return repository.UpsertNotificationParams{
 		AppID:                   n.AppID,
 		IncludedSegments:        n.IncludedSegments,
 		ExcludedSegments:        n.ExcludedSegments,
@@ -215,6 +275,8 @@ func (pns *pushNotificationService) notificationToCreateParams(
 		OnesignalStatus:         n.OnesignalStatus,
 		OnesignalResponse:       n.OnesignalResponse,
 		OnesignalError:          n.OnesignalError,
+		QueueMessageID:          n.QueueMessageID,
+		Status:                  n.Status,
 	}
 }
 

--- a/internal/service/push_notification_service_test.go
+++ b/internal/service/push_notification_service_test.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/opencrafts-io/gossip-monger/internal/repository"
+	"github.com/opencrafts-io/gossip-monger/internal/resilience"
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeQuerier embeds the (large) repository.Querier interface as a nil
+// value so tests only need to implement the one method they exercise;
+// calling any other method panics on the nil embedded interface, which is
+// the point — it surfaces an unexpected call immediately.
+type fakeQuerier struct {
+	repository.Querier
+	upsertNotification        func(ctx context.Context, arg repository.UpsertNotificationParams) (repository.Notification, error)
+	getNotificationByQueueMsg func(ctx context.Context, id *string) (repository.Notification, error)
+}
+
+func (f *fakeQuerier) UpsertNotification(
+	ctx context.Context,
+	arg repository.UpsertNotificationParams,
+) (repository.Notification, error) {
+	return f.upsertNotification(ctx, arg)
+}
+
+func (f *fakeQuerier) GetNotificationByQueueMessageID(
+	ctx context.Context,
+	id *string,
+) (repository.Notification, error) {
+	if f.getNotificationByQueueMsg != nil {
+		return f.getNotificationByQueueMsg(ctx, id)
+	}
+	// Default: no existing row, i.e. not a duplicate.
+	return repository.Notification{}, pgx.ErrNoRows
+}
+
+// fakeBreaker lets a test force the breaker-open path without waiting on
+// real consecutive failures/timeouts, and tracks whether it was invoked at
+// all so a test can assert the provider was never reached.
+type fakeBreaker[T any] struct {
+	forcedErr error
+	calls     *int
+}
+
+func (f fakeBreaker[T]) Execute(req func() (T, error)) (T, error) {
+	if f.calls != nil {
+		*f.calls++
+	}
+	if f.forcedErr != nil {
+		var zero T
+		return zero, f.forcedErr
+	}
+	return req()
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func validPushNotification() repository.Notification {
+	return repository.Notification{
+		Headings:         json.RawMessage(`{"en":"hi"}`),
+		Contents:         json.RawMessage(`{"en":"body"}`),
+		IncludedSegments: []string{"Active Users"},
+	}
+}
+
+func TestSend_BreakerOpen_RecordsCircuitOpenAndReturnsError(t *testing.T) {
+	var captured repository.UpsertNotificationParams
+	repo := &fakeQuerier{
+		upsertNotification: func(_ context.Context, arg repository.UpsertNotificationParams) (repository.Notification, error) {
+			captured = arg
+			return repository.Notification{}, nil
+		},
+	}
+
+	pns := &pushNotificationService{
+		repo:    repo,
+		logger:  testLogger(),
+		breaker: fakeBreaker[*onesignalCallResult]{forcedErr: gobreaker.ErrOpenState},
+	}
+
+	err := pns.Send(context.Background(), validPushNotification(), "req-123")
+
+	require.Error(t, err)
+	assert.True(t, resilience.Open(err))
+	require.NotNil(t, captured.Status)
+	assert.Equal(t, "circuit_open", *captured.Status)
+	require.NotNil(t, captured.QueueMessageID)
+	assert.Equal(t, "req-123", *captured.QueueMessageID)
+}
+
+func TestSend_ValidationError_PersistsFailedStatusWithoutCallingProvider(t *testing.T) {
+	var captured repository.UpsertNotificationParams
+	calls := 0
+	repo := &fakeQuerier{
+		upsertNotification: func(_ context.Context, arg repository.UpsertNotificationParams) (repository.Notification, error) {
+			captured = arg
+			return repository.Notification{}, nil
+		},
+	}
+
+	pns := &pushNotificationService{
+		repo:    repo,
+		logger:  testLogger(),
+		breaker: fakeBreaker[*onesignalCallResult]{calls: &calls},
+	}
+
+	// No targeting mechanism specified at all -> preparePushPayload fails
+	// before the breaker/provider is ever reached.
+	invalid := repository.Notification{
+		Headings: json.RawMessage(`{"en":"hi"}`),
+		Contents: json.RawMessage(`{"en":"body"}`),
+	}
+
+	err := pns.Send(context.Background(), invalid, "req-456")
+
+	require.Error(t, err)
+	assert.Equal(t, 0, calls, "breaker/provider must not be invoked when payload validation fails")
+	require.NotNil(t, captured.Status)
+	assert.Equal(t, "failed", *captured.Status)
+	require.NotNil(t, captured.QueueMessageID)
+	assert.Equal(t, "req-456", *captured.QueueMessageID)
+}
+
+func TestSend_QueueMessageIDThreadedThroughOnEveryAttempt(t *testing.T) {
+	var seen []string
+	repo := &fakeQuerier{
+		upsertNotification: func(_ context.Context, arg repository.UpsertNotificationParams) (repository.Notification, error) {
+			if arg.QueueMessageID != nil {
+				seen = append(seen, *arg.QueueMessageID)
+			}
+			return repository.Notification{}, nil
+		},
+	}
+
+	pns := &pushNotificationService{
+		repo:    repo,
+		logger:  testLogger(),
+		breaker: fakeBreaker[*onesignalCallResult]{forcedErr: gobreaker.ErrOpenState},
+	}
+
+	// Same queueMessageID sent twice, simulating a dead-lettered redelivery
+	// of the same logical message. Both attempts must record against the
+	// same id so the DB-level upsert (ON CONFLICT (queue_message_id)) dedupes
+	// them into one row instead of erroring on a second insert.
+	_ = pns.Send(context.Background(), validPushNotification(), "req-same")
+	_ = pns.Send(context.Background(), validPushNotification(), "req-same")
+
+	require.Len(t, seen, 2)
+	assert.Equal(t, "req-same", seen[0])
+	assert.Equal(t, "req-same", seen[1])
+}
+
+func TestSend_DuplicateAlreadySent_SkipsResendWithoutCallingProvider(t *testing.T) {
+	sentStatus := "sent"
+	calls := 0
+	repo := &fakeQuerier{
+		getNotificationByQueueMsg: func(_ context.Context, id *string) (repository.Notification, error) {
+			return repository.Notification{Status: &sentStatus}, nil
+		},
+	}
+
+	pns := &pushNotificationService{
+		repo:    repo,
+		logger:  testLogger(),
+		breaker: fakeBreaker[*onesignalCallResult]{calls: &calls},
+	}
+
+	err := pns.Send(context.Background(), validPushNotification(), "req-already-sent")
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, calls, "an already-sent queue_message_id must not trigger a second real send")
+}


### PR DESCRIPTION
## Summary

Adds a circuit breaker and automatic retry-with-backoff for the OneSignal and Resend integrations. Before this, a provider outage or transient error meant the message was silently, permanently lost — no DLQ, no retry, and for push notifications, no database record of the failure at all.

**Base branch:** `staging`.

## What changed

- **Circuit breaker** (`internal/resilience`, `sony/gobreaker/v2`) — independent breakers around the OneSignal and Resend calls, configurable via new `BREAKER_*` env vars, state transitions logged.
- **Retry instead of silent drop** — the email and push queues now dead-letter into a shared `gossip.retry.exchange` → `gossip.retry.queue` (TTL-delayed) → back to the original queue, up to `MAX_RETRY_ATTEMPTS` (tracked via RabbitMQ's own `x-death` header, no schema needed for that), then to `gossip.parked.queue` for manual triage. `broker.Publisher`, previously fully implemented but never called, gets its first real caller.
- **Two real bugs fixed, not just the breaker added:**
  - `emailService.Send` swallowed the Resend error and returned `nil` — the consumer would `Ack` a failed send as if it succeeded. It now propagates the error so it retries.
  - `pushNotificationService.Send` never persisted anything on failure. Every outcome (`sent`/`failed`/`circuit_open`) is now recorded.
- **Idempotency**: retrying via requeue means the same message gets reprocessed, so `email_requests`/`notifications` moved from insert-always to upsert-by-`queue_message_id` (new column + migration for `notifications`). That alone would let an *external* duplicate republish trigger a second real send, so both services now check for an already-dispatched/sent duplicate before attempting a send.
- **Docs**: ADR-0006 records the decision and its deliberate deferrals (no metrics stack yet, single fixed retry delay, `user_consumer.go` left out of scope since it doesn't call a third-party API). Both integration guides' retry/idempotency sections rewritten to match actual behavior.

## Commits

- `feat(resilience)`: circuit breaker wrapper
- `feat(config)`: breaker and retry configuration
- `feat(db)`: idempotency support for retried sends
- `fix(email)`: stop silently dropping failed sends
- `fix(push)`: persist every send outcome, not only successes
- `feat(broker)`: retry failed messages via dead-letter instead of dropping them
- `docs(adr)`: record decision, update guides

## Test plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` clean, including new breaker unit tests and push-service tests covering breaker-open, validation-failure, duplicate-detection, and retry-idempotency paths
- [x] `sqlc generate` runs clean against the new migration + queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic delayed retries for email and push notifications.
  * Added circuit-breaker protection for third-party notification providers.
  * Added duplicate-send prevention using request identifiers.
  * Messages that exceed retry limits are routed for manual review.

* **Bug Fixes**
  * Failed and circuit-blocked delivery attempts now retain accurate statuses and provider details.

* **Documentation**
  * Updated integration guides with retry, idempotency, and failure-handling behavior.

* **Configuration**
  * Added settings for retry delays, retry limits, and circuit-breaker thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->