### PR TITLE
feat: containerize gossip-monger for Dokploy via docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.env
+tmp/
+.reports/
+*.log

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -44,9 +44,21 @@ jobs:
       - name: Build and Push Docker Image
         run: |
           IMAGE="${{ steps.img.outputs.image }}"
-          echo "Building and pushing image: $IMAGE"
-          docker build -t "$IMAGE" .
-          docker push "$IMAGE"
+          TAGS=("$IMAGE")
+          if [ "${{ github.ref_name }}" = "main" ] || [ "${{ github.ref_name }}" = "master" ]; then
+            TAGS+=("opencrafts/notifications-backend-prod:latest")
+          fi
+
+          BUILD_ARGS=()
+          for T in "${TAGS[@]}"; do BUILD_ARGS+=(-t "$T"); done
+
+          echo "Building image with tags: ${TAGS[*]}"
+          docker build "${BUILD_ARGS[@]}" .
+
+          for T in "${TAGS[@]}"; do
+            echo "Pushing $T"
+            docker push "$T"
+          done
 
       - name: Checkout InfraOps Repo
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,7 @@ FROM alpine:3.18 AS final
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 COPY --from=builder /app /app
+
+WORKDIR /
+
+CMD ["/app"]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Copy [`example.env`](example.env) to `.env` and fill in your own values.
 | `RESEND_ALLOWED_SENDER_DOMAINS` | Comma-separated domains a `from_address` is allowed to end with |
 | `GOOSE_*` | Migration runner settings |
 
+## Deploying via Dokploy
+
+[`docker-compose.yml`](docker-compose.yml) runs the app container only — it
+does not bundle Postgres or RabbitMQ, both of which are expected to already
+be reachable on the network (Postgres via `DB_*` env vars, RabbitMQ via
+`RABBITMQ_*`). Set every variable in the table above through Dokploy's
+environment variable UI; `GOOSE_*` vars are only used by the standalone
+`goose` CLI for manual migrations and are not needed here — migrations run
+automatically on startup regardless.
+
 ## Local development
 
 Requires Go 1.25+, PostgreSQL, and RabbitMQ running locally.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  app:
+    image: opencrafts/notifications-backend-prod:latest
+    pull_policy: always
+    restart: unless-stopped
+    environment:
+      # Application configuration
+      # NOTE: bind address defaults to 0.0.0.0, not "localhost" — the app
+      # must be reachable from Traefik/other containers on the network.
+      GOSSIP_MONGER_PORT: ${GOSSIP_MONGER_PORT:-6969}
+      GOSSIP_MONGER_ADDRESS: ${GOSSIP_MONGER_ADDRESS:-0.0.0.0}
+
+      # Database configuration — an existing Postgres instance, not managed
+      # by this stack. Provide these via Dokploy's environment variables.
+      DB_HOST: ${DB_HOST}
+      DB_DRIVER: ${DB_DRIVER:-postgres}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_MAX_CON: ${DB_MAX_CON:-10}
+      DB_POOL_MIN_CON: ${DB_POOL_MIN_CON:-2}
+      DB_POOL_MAX_LIFETIME: ${DB_POOL_MAX_LIFETIME:-24}
+
+      # RabbitMQ configuration — reuses an existing broker already reachable
+      # on rizzit_net.
+      RABBITMQ_USER: ${RABBITMQ_USER}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
+      RABBITMQ_ADDRESS: ${RABBITMQ_ADDRESS}
+      RABBITMQ_PORT: ${RABBITMQ_PORT:-5672}
+      RETRY_DELAY_SECONDS: ${RETRY_DELAY_SECONDS:-30}
+      MAX_RETRY_ATTEMPTS: ${MAX_RETRY_ATTEMPTS:-5}
+
+      # Circuit breaker configuration
+      BREAKER_CONSECUTIVE_FAILURES: ${BREAKER_CONSECUTIVE_FAILURES:-5}
+      BREAKER_OPEN_TIMEOUT_SECONDS: ${BREAKER_OPEN_TIMEOUT_SECONDS:-30}
+      BREAKER_HALF_OPEN_MAX_REQUESTS: ${BREAKER_HALF_OPEN_MAX_REQUESTS:-1}
+
+      # OneSignal configuration
+      ONESIGNAL_APP_ID: ${ONESIGNAL_APP_ID}
+      ONESIGNAL_REST_API_KEY: ${ONESIGNAL_REST_API_KEY}
+
+      # Resend configuration
+      RESEND_API_KEY: ${RESEND_API_KEY}
+      RESEND_ALLOWED_SENDER_DOMAINS: ${RESEND_ALLOWED_SENDER_DOMAINS:-@posta.opencrafts.io}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=dokploy-network"
+      - "traefik.http.routers.gossip-monger.rule=Host(`gossip.rizzit.cloud`)"
+      - "traefik.http.routers.gossip-monger.entrypoints=websecure"
+      - "traefik.http.routers.gossip-monger.tls.certResolver=letsencrypt"
+      - "traefik.http.services.gossip-monger.loadbalancer.server.port=${GOSSIP_MONGER_PORT:-6969}"
+    networks:
+      - default
+      - dokploy-network
+
+networks:
+  default:
+    name: rizzit_net
+    external: true
+  dokploy-network:
+    external: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
@@ -69,8 +70,10 @@ type Config struct {
 func LoadConfig() (*Config, error) {
 	cfg := Config{}
 
-	// load the configs
-	if err := godotenv.Load(".env"); err != nil {
+	// load the configs. A missing .env file is fine — deployments such as
+	// Dokploy inject environment variables directly into the container
+	// instead of mounting a .env file.
+	if err := godotenv.Load(".env"); err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("Failed to load environment variables: %v", err)
 	}
 	if err := envconfig.Process("", &cfg); err != nil {


### PR DESCRIPTION
Add a docker-compose.yml for a self-hosted Dokploy deployment that runs the app container only, connecting to externally managed Postgres and RabbitMQ over the rizzit_net/dokploy-network networks. Fix two bugs found along the way: the Dockerfile's final stage never set CMD/ENTRYPOINT, and config.go treated a missing .env file as fatal even though Dokploy injects env vars directly. Also add .dockerignore so local builds never bake a .env file into image layers, and push a :latest tag from CI on main so pull_policy: always has something to fetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Docker Compose deployment support with automatic restarts, configurable service settings, and secure routing.
  - Container images now support commit-specific tags and a `latest` tag for the main branch.
  - Containers launch with the application configured as the default command.

- **Bug Fixes**
  - Deployments no longer fail when an optional environment file is missing.

- **Documentation**
  - Added Dokploy deployment instructions, configuration guidance, and startup migration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->